### PR TITLE
pping: Add IPv6 support

### DIFF
--- a/pping/TODO.md
+++ b/pping/TODO.md
@@ -1,18 +1,28 @@
 # TODO
 
-## For initial merge
+## Protocols
+- [x] TCP (based on timestamp options)
+  - [ ] Skip pure ACKs for egress?
+  - [ ] Add fallback to SEQ/ACK in case of no timestamp?
+- [ ] ICMP (ex Echo/Reply)
+- [ ] QUIC (based on spinbit)
+
+## General pping
+- [ ] Use libxdp to load XDP program
+- [ ] Check for existance of reverse flow before adding to hash-map (to avoid adding identifiers for flows that we can't see the reverse traffic for)?
+  -  This could miss the first few packets, would not be ideal for short flows
+- [ ] Keep track of minimum RTT for each flow (done by Pollere's pping, and helps identify buffer bloat)
+- [ ] Add configurable rate-limit for how often each flow can add entries to the map (prevent high-rate flows from quickly filling up the map)
+- [ ] Improve map cleaning: Use a dynamic time to live for hash map entries based on flow's RTT, instead of static 10s limit
+- [ ] Add support for automatically deleting entries if they are unique
+  - TCP timestamp need to be kept for a while (because multiple packets can have the same timestamp), but for identifiers that are unique per packet, they can be removed directly after RTT is calculated
+
+## Done
 - [x] Clean up commits and add signed-off-by tags
 - [x] Add SPDX-license-identifier tags
 - [x] Format C-code in kernel style
 - [x] Use existing funcionality to reuse maps by using BTF-defined maps
   - [x] Use BTF-defined maps for TC-BPF as well if iproute has libbpf support
-
-## Future
-- [ ] Use libxdp to load XDP program
 - [x] Cleanup: Unload TC-BPF at program shutdown, and unpin map - In userspace part
-- [ ] Add IPv6 support - In TC-BPF, XDP and userspace part
-- [ ] Check for existance of reverse flow before adding to hash-map (to avoid adding timestamps for flows that we can't see the reverse traffic for) - In TC-BPF part
-  -  This could miss the first few packets, would not be ideal for short flows
-- [ ] Keep track of minimum RTT for each flow (done by Pollere's pping, and helps identify buffer bloat) - In XDP part
-- [ ] Add configurable rate-limit for how often each flow can add entries to the map (prevent high-rate flows from quickly filling up the map) - In TCP-BPF part
-- [ ] Improve map cleaning: Use a dynamic time to live for hash map entries based on flow's RTT, instead of static 10s limit - In TC-BPF, XDP and userspace
+- [x] Add IPv6 support
+- [x] Refactor to support easy addition of other protocols

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -248,7 +248,7 @@ static int format_ip_address(int af, const struct in6_addr *addr, char *buf,
 			     size_t size)
 {
 	if (af == AF_INET)
-		return inet_ntop(af, &(addr->s6_addr[12]),
+		return inet_ntop(af, &addr->s6_addr[12],
 				 buf, size) ? -errno : 0;
 	else if (af == AF_INET6)
 		return inet_ntop(af, addr, buf, size) ? -errno : 0;
@@ -261,8 +261,8 @@ static void handle_rtt_event(void *ctx, int cpu, void *data, __u32 data_size)
 	char saddr[INET6_ADDRSTRLEN];
 	char daddr[INET6_ADDRSTRLEN];
 
-	format_ip_address(e->flow.ipv, &(e->flow.saddr), saddr, sizeof(saddr));
-	format_ip_address(e->flow.ipv, &(e->flow.daddr), daddr, sizeof(daddr));
+	format_ip_address(e->flow.ipv, &e->flow.saddr, saddr, sizeof(saddr));
+	format_ip_address(e->flow.ipv, &e->flow.daddr, daddr, sizeof(daddr));
 
 	printf("%llu.%06llu ms %s:%d+%s:%d\n", e->rtt / NS_PER_MS,
 	       e->rtt % NS_PER_MS, saddr, ntohs(e->flow.sport), daddr,

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -81,7 +81,7 @@ static int set_rlimit(long int lim)
 static int mkdir_if_noexist(const char *path)
 {
 	int ret;
-	struct stat st = {0};
+	struct stat st = { 0 };
 
 	ret = stat(path, &st);
 	if (ret) {
@@ -261,12 +261,12 @@ static void handle_rtt_event(void *ctx, int cpu, void *data, __u32 data_size)
 	char saddr[INET6_ADDRSTRLEN];
 	char daddr[INET6_ADDRSTRLEN];
 
-	format_ip_address(e->flow.ipv, &e->flow.saddr, saddr, sizeof(saddr));
-	format_ip_address(e->flow.ipv, &e->flow.daddr, daddr, sizeof(daddr));
+	format_ip_address(e->flow.ipv, &e->flow.saddr.ip, saddr, sizeof(saddr));
+	format_ip_address(e->flow.ipv, &e->flow.daddr.ip, daddr, sizeof(daddr));
 
 	printf("%llu.%06llu ms %s:%d+%s:%d\n", e->rtt / NS_PER_MS,
-	       e->rtt % NS_PER_MS, saddr, ntohs(e->flow.sport), daddr,
-	       ntohs(e->flow.dport));
+	       e->rtt % NS_PER_MS, saddr, ntohs(e->flow.saddr.port), daddr,
+	       ntohs(e->flow.daddr.port));
 }
 
 static void handle_missed_rtt_event(void *ctx, int cpu, __u64 lost_cnt)

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -9,21 +9,29 @@
 #define TCBPF_PROG_SEC "pping_egress"
 
 /*
- * Struct to hold a full network tuple
+ * Struct that can hold the source or destination address for a flow (l3+l4).
  * Works for both IPv4 and IPv6, as IPv4 addresses can be mapped to IPv6 ones
- * based on RFC 4291 Section 2.5.5.2. The ipv member is technically not 
- * necessary, but makes it easier to determine if it is an IPv4 or IPv6 address
- * (don't need to look at the first 12 bytes of address).
- * The proto memeber is not currently used, but could be useful once pping
- * is extended to work for other protocols than TCP
+ * based on RFC 4291 Section 2.5.5.2.
+ */
+struct flow_address {
+	struct in6_addr ip;
+	__u16 port;
+	__u16 reserved;
+};
+
+/*
+ * Struct to hold a full network tuple
+ * The ipv member is technically not necessary, but makes it easier to 
+ * determine if saddr/daddr are IPv4 or IPv6 address (don't need to look at the
+ * first 12 bytes of address). The proto memeber is not currently used, but 
+ * could be useful once pping is extended to work for other protocols than TCP.
  */
 struct network_tuple {
-	struct in6_addr saddr;
-	struct in6_addr daddr;
-	__u16 sport;
-	__u16 dport;
+	struct flow_address saddr;
+	struct flow_address daddr;
 	__u16 proto; //IPPROTO_TCP, IPPROTO_ICMP, QUIC etc
-	__u16 ipv; //AF_INET or AF_INET6
+	__u8 ipv; //AF_INET or AF_INET6
+	__u8 reserved;
 };
 
 struct packet_id {
@@ -34,11 +42,13 @@ struct packet_id {
 struct packet_timestamp {
 	__u64 timestamp;
 	__u8 used;
+	__u8 reserved[7];
 };
 
 struct rtt_event {
 	__u64 rtt;
 	struct network_tuple flow;
+	__u32 reserved;
 };
 
 #endif

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -3,30 +3,41 @@
 #define PPING_H
 
 #include <linux/types.h>
+#include <linux/in6.h>
 
 #define XDP_PROG_SEC "xdp"
 #define TCBPF_PROG_SEC "pping_egress"
 
-// TODO - change to support both IPv4 and IPv6 (IPv4 addresses can be mapped to IPv6 addresses)
-struct ipv4_flow {
-	__u32 saddr;
-	__u32 daddr;
+/*
+ * Struct to hold a full network tuple
+ * Works for both IPv4 and IPv6, as IPv4 addresses can be mapped to IPv6 ones
+ * based on RFC 4291 Section 2.5.5.2. The ipv member is technically not 
+ * necessary, but makes it easier to determine if it is an IPv4 or IPv6 address
+ * (don't need to look at the first 12 bytes of address).
+ * The proto memeber is not currently used, but could be useful once pping
+ * is extended to work for other protocols than TCP
+ */
+struct network_tuple {
+	__u8 ipv; //AF_INET or AF_INET6
+	struct in6_addr saddr;
+	struct in6_addr daddr;
 	__u16 sport;
 	__u16 dport;
+	__u16 proto; //IPPROTO_TCP, IPPROTO_ICMP, QUIC etc
 };
 
-struct ts_key {
-	struct ipv4_flow flow;
-	__u32 tsval;
+struct packet_id {
+	struct network_tuple flow;
+	__u32 identifier; //tsval for TCP packets
 };
 
-struct ts_timestamp {
+struct packet_timestamp {
 	__u64 timestamp;
 	__u8 used;
 };
 
 struct rtt_event {
-	struct ipv4_flow flow;
+	struct network_tuple flow;
 	__u64 rtt;
 };
 

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -18,12 +18,12 @@
  * is extended to work for other protocols than TCP
  */
 struct network_tuple {
-	__u8 ipv; //AF_INET or AF_INET6
 	struct in6_addr saddr;
 	struct in6_addr daddr;
 	__u16 sport;
 	__u16 dport;
 	__u16 proto; //IPPROTO_TCP, IPPROTO_ICMP, QUIC etc
+	__u16 ipv; //AF_INET or AF_INET6
 };
 
 struct packet_id {
@@ -37,8 +37,8 @@ struct packet_timestamp {
 };
 
 struct rtt_event {
-	struct network_tuple flow;
 	__u64 rtt;
+	struct network_tuple flow;
 };
 
 #endif

--- a/pping/pping_helpers.h
+++ b/pping/pping_helpers.h
@@ -29,7 +29,7 @@ struct parsing_context {
 	void *data;           //Start of eth hdr
 	void *data_end;       //End of safe acessible area
 	struct hdr_cursor nh; //Position to parse next
-	__u32 len;            //Full packet length (headers+data)
+	__u32 pkt_len;        //Full packet length (headers+data)
 };
 
 /*
@@ -109,7 +109,7 @@ static int parse_tcp_identifier(struct parsing_context *ctx, bool is_egress,
 		return -1;
 
 	// Do not timestamp pure ACKs
-	if (is_egress && ctx->nh.pos - ctx->data >= ctx->len && !tcph->syn)
+	if (is_egress && ctx->nh.pos - ctx->data >= ctx->pkt_len && !tcph->syn)
 		return -1;
 
 	if (parse_tcp_ts(tcph, ctx->data_end, &tsval, &tsecr) < 0)

--- a/pping/pping_helpers.h
+++ b/pping/pping_helpers.h
@@ -7,6 +7,8 @@
 #include <string.h>
 #include "pping.h"
 
+#define AF_INET 2
+#define AF_INET6 10
 #define MAX_TCP_OPTIONS 10
 
 /*
@@ -15,14 +17,10 @@
 static __always_inline void map_ipv4_to_ipv6(__be32 ipv4, struct in6_addr *ipv6)
 {
 	/* __u16 ipv4_prefix[6] = {0x0, 0x0, 0x0, 0x0, 0x0, 0xffff}; */
-	/* memcpy(&(ipv6->in6_u.u6_addr8), ipv4_prefix, sizeof(ipv4_prefix)); */
-	memset(&(ipv6->in6_u.u6_addr8[0]), 0x00, 10);
-	memset(&(ipv6->in6_u.u6_addr8[10]), 0xff, 2);
-#if __UAPI_DEF_IN6_ADDR_ALT
+	/* memcpy(ipv6, ipv4_prefix, sizeof(ipv4_prefix)); // Won't load on TC */
+	memset(&ipv6->in6_u.u6_addr8[0], 0x00, 10);
+	memset(&ipv6->in6_u.u6_addr8[10], 0xff, 2);
 	ipv6->in6_u.u6_addr32[3] = ipv4;
-#else
-	memcpy(&(ipv6->in6_u.u6_addr8[12]), &ipv4, sizeof(ipv4));
-#endif
 }
 
 /*

--- a/pping/pping_helpers.h
+++ b/pping/pping_helpers.h
@@ -2,19 +2,27 @@
 #ifndef PPING_HELPERS_H
 #define PPING_HELPERS_H
 
-#include "pping.h"
+#include <linux/in6.h>
 #include <linux/tcp.h>
+#include <string.h>
+#include "pping.h"
 
 #define MAX_TCP_OPTIONS 10
 
-static __always_inline int fill_ipv4_flow(struct ipv4_flow *flow, __u32 saddr,
-					  __u32 daddr, __u16 sport, __u16 dport)
+/*
+ * Maps and IPv4 address into an IPv6 address according to RFC 4291 sec 2.5.5.2
+ */
+static __always_inline void map_ipv4_to_ipv6(__be32 ipv4, struct in6_addr *ipv6)
 {
-	flow->saddr = saddr;
-	flow->daddr = daddr;
-	flow->sport = sport;
-	flow->dport = dport;
-	return 0;
+	/* __u16 ipv4_prefix[6] = {0x0, 0x0, 0x0, 0x0, 0x0, 0xffff}; */
+	/* memcpy(&(ipv6->in6_u.u6_addr8), ipv4_prefix, sizeof(ipv4_prefix)); */
+	memset(&(ipv6->in6_u.u6_addr8[0]), 0x00, 10);
+	memset(&(ipv6->in6_u.u6_addr8[10]), 0xff, 2);
+#if __UAPI_DEF_IN6_ADDR_ALT
+	ipv6->in6_u.u6_addr32[3] = ipv4;
+#else
+	memcpy(&(ipv6->in6_u.u6_addr8[12]), &ipv4, sizeof(ipv4));
+#endif
 }
 
 /*

--- a/pping/pping_helpers.h
+++ b/pping/pping_helpers.h
@@ -2,9 +2,16 @@
 #ifndef PPING_HELPERS_H
 #define PPING_HELPERS_H
 
+#include <linux/bpf.h>
+#include <xdp/parsing_helpers.h>
+#include <linux/in.h>
 #include <linux/in6.h>
+#include <linux/if_ether.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
 #include <linux/tcp.h>
-#include <string.h>
+
+#include <stdbool.h>
 #include "pping.h"
 
 #define AF_INET 2
@@ -14,12 +21,12 @@
 /*
  * Maps and IPv4 address into an IPv6 address according to RFC 4291 sec 2.5.5.2
  */
-static __always_inline void map_ipv4_to_ipv6(__be32 ipv4, struct in6_addr *ipv6)
+static void map_ipv4_to_ipv6(__be32 ipv4, struct in6_addr *ipv6)
 {
 	/* __u16 ipv4_prefix[6] = {0x0, 0x0, 0x0, 0x0, 0x0, 0xffff}; */
-	/* memcpy(ipv6, ipv4_prefix, sizeof(ipv4_prefix)); // Won't load on TC */
-	memset(&ipv6->in6_u.u6_addr8[0], 0x00, 10);
-	memset(&ipv6->in6_u.u6_addr8[10], 0xff, 2);
+	/* __builtin_memcpy(ipv6, ipv4_prefix, sizeof(ipv4_prefix)); */
+	__builtin_memset(&ipv6->in6_u.u6_addr8[0], 0x00, 10);
+	__builtin_memset(&ipv6->in6_u.u6_addr8[10], 0xff, 2);
 	ipv6->in6_u.u6_addr32[3] = ipv4;
 }
 
@@ -29,8 +36,8 @@ static __always_inline void map_ipv4_to_ipv6(__be32 ipv4, struct in6_addr *ipv6)
  * byte order).
  * Returns 0 if sucessful and -1 on failure
  */
-static __always_inline int parse_tcp_ts(struct tcphdr *tcph, void *data_end,
-                                        __u32 *tsval, __u32 *tsecr)
+static int parse_tcp_ts(struct tcphdr *tcph, void *data_end, __u32 *tsval,
+			__u32 *tsecr)
 {
 	int len = tcph->doff << 2;
 	void *opt_end = (void *)tcph + len;
@@ -72,6 +79,81 @@ static __always_inline int parse_tcp_ts(struct tcphdr *tcph, void *data_end,
 		pos += opt_size;
 	}
 	return -1;
+}
+/*
+ * Attempts to fetch an identifier for TCP packets, based on the TCP timestamp
+ * option. If sucessful, identifier will be set to TSval if is_ingress, TSecr
+ * otherwise, the port-members of saddr and daddr will be set the the TCP source
+ * and dest, respectively, and 0 will be returned. On failure, -1 will be
+ * returned.
+ */
+static int parse_tcp_identifier(struct hdr_cursor *nh, void *data_end,
+				bool is_egress, struct flow_address *saddr,
+				struct flow_address *daddr, __u32 *identifier)
+{
+	__u32 tsval, tsecr;
+	struct tcphdr *tcph;
+
+	if (parse_tcphdr(nh, data_end, &tcph) < 0)
+		return -1;
+	if (parse_tcp_ts(tcph, data_end, &tsval, &tsecr) < 0)
+		return -1; //Possible TODO, fall back on seq/ack instead
+
+	saddr->port = tcph->source;
+	daddr->port = tcph->dest;
+	*identifier = is_egress ? tsval : tsecr;
+	return 0;
+}
+
+/*
+ * Attempts to parse the packet limited by the data and data_end pointers,
+ * to retrieve a protocol dependent packet identifier. If sucessful, the
+ * ipv and identifier of p_id will be set, saddr and daddr (which may be part
+ * of p_id) will be filled with the source and destionation addresses of the
+ * packet, and 0 will be returned. On failure, -1 will be returned.
+ */
+static int parse_packet_identifier(void *data, void *data_end, bool is_egress,
+				   struct packet_id *p_id,
+				   struct flow_address *saddr,
+				   struct flow_address *daddr)
+{
+	struct hdr_cursor nh = { .pos = data };
+	struct ethhdr *eth;
+	struct iphdr *iph;
+	struct ipv6hdr *ip6h;
+	int proto, err;
+
+	proto = parse_ethhdr(&nh, data_end, &eth);
+
+	// Parse IPv4/6 header
+	if (proto == bpf_htons(ETH_P_IP)) {
+		p_id->flow.ipv = AF_INET;
+		proto = parse_iphdr(&nh, data_end, &iph);
+	} else if (proto == bpf_htons(ETH_P_IPV6)) {
+		p_id->flow.ipv = AF_INET6;
+		proto = parse_ip6hdr(&nh, data_end, &ip6h);
+	} else
+		return -1;
+
+	// Add new protocols here
+	if (proto == IPPROTO_TCP)
+		err = parse_tcp_identifier(&nh, data_end, is_egress, saddr,
+					   daddr, &p_id->identifier);
+	else
+		return -1;
+
+	if (err)
+		return -1;
+
+	// Sucessfully parsed packet identifier - fill in IP-addresses and return
+	if (p_id->flow.ipv == AF_INET) {
+		map_ipv4_to_ipv6(iph->saddr, &saddr->ip);
+		map_ipv4_to_ipv6(iph->daddr, &daddr->ip);
+	} else { // IPv6
+		saddr->ip = ip6h->saddr;
+		daddr->ip = ip6h->daddr;
+	}
+	return 0;
 }
 
 #endif

--- a/pping/pping_kern_tc.c
+++ b/pping/pping_kern_tc.c
@@ -31,14 +31,14 @@ struct bpf_elf_map SEC("maps") ts_start = {
 SEC(TCBPF_PROG_SEC)
 int tc_bpf_prog_egress(struct __sk_buff *skb)
 {
-	struct parsing_context pctx;
 	struct packet_id p_id = { 0 };
 	struct packet_timestamp p_ts = { 0 };
-
-	pctx.data = (void *)(long)skb->data;
-	pctx.data_end = (void *)(long)skb->data_end;
-	pctx.len = skb->len;
-	pctx.nh.pos = pctx.data;
+	struct parsing_context pctx = {
+		.data = (void *)(long)skb->data,
+		.data_end = (void *)(long)skb->data_end,
+		.pkt_len = skb->len,
+		.nh = { .pos = pctx.data },
+	};
 
 	if (parse_packet_identifier(&pctx, true, &p_id) < 0)
 		goto end;

--- a/pping/pping_kern_tc.c
+++ b/pping/pping_kern_tc.c
@@ -31,13 +31,16 @@ struct bpf_elf_map SEC("maps") ts_start = {
 SEC(TCBPF_PROG_SEC)
 int tc_bpf_prog_egress(struct __sk_buff *skb)
 {
+	struct parsing_context pctx;
 	struct packet_id p_id = { 0 };
 	struct packet_timestamp p_ts = { 0 };
 
-	void *data = (void *)(long)skb->data;
-	void *data_end = (void *)(long)skb->data_end;
+	pctx.data = (void *)(long)skb->data;
+	pctx.data_end = (void *)(long)skb->data_end;
+	pctx.data_end_end = pctx.data + skb->len;
+	pctx.nh.pos = pctx.data;
 
-	if (parse_packet_identifier(data, data_end, true, &p_id) < 0)
+	if (parse_packet_identifier(&pctx, true, &p_id) < 0)
 		goto end;
 
 	p_ts.timestamp = bpf_ktime_get_ns(); // or bpf_ktime_get_boot_ns

--- a/pping/pping_kern_tc.c
+++ b/pping/pping_kern_tc.c
@@ -37,7 +37,7 @@ int tc_bpf_prog_egress(struct __sk_buff *skb)
 
 	pctx.data = (void *)(long)skb->data;
 	pctx.data_end = (void *)(long)skb->data_end;
-	pctx.data_end_end = pctx.data + skb->len;
+	pctx.len = skb->len;
 	pctx.nh.pos = pctx.data;
 
 	if (parse_packet_identifier(&pctx, true, &p_id) < 0)

--- a/pping/pping_kern_tc.c
+++ b/pping/pping_kern_tc.c
@@ -37,8 +37,7 @@ int tc_bpf_prog_egress(struct __sk_buff *skb)
 	void *data = (void *)(long)skb->data;
 	void *data_end = (void *)(long)skb->data_end;
 
-	if (parse_packet_identifier(data, data_end, true, &p_id,
-				    &p_id.flow.saddr, &p_id.flow.daddr) < 0)
+	if (parse_packet_identifier(data, data_end, true, &p_id) < 0)
 		goto end;
 
 	p_ts.timestamp = bpf_ktime_get_ns(); // or bpf_ktime_get_boot_ns

--- a/pping/pping_kern_tc.c
+++ b/pping/pping_kern_tc.c
@@ -2,16 +2,6 @@
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
 #include <iproute2/bpf_elf.h>
-#include <xdp/parsing_helpers.h>
-
-#include <linux/in.h>
-#include <linux/in6.h>
-#include <linux/if_ether.h>
-#include <linux/ip.h>
-#include <linux/ipv6.h>
-#include <linux/tcp.h>
-
-#include <string.h>
 
 #include "pping.h"
 #include "pping_helpers.h"
@@ -37,56 +27,19 @@ struct bpf_elf_map SEC("maps") ts_start = {
 };
 #endif
 
-// TC-BFP for parsing TSVAL from egress traffic and add to map
+// TC-BFP for parsing packet identifier from egress traffic and add to map
 SEC(TCBPF_PROG_SEC)
 int tc_bpf_prog_egress(struct __sk_buff *skb)
 {
-	void *data = (void *)(long)skb->data;
-	void *data_end = (void *)(long)skb->data_end;
-
-	int proto = -1;
-	__u32 tsval, tsecr;
-
-	struct hdr_cursor nh = { .pos = data };
-	struct ethhdr *eth;
-	struct iphdr *iph;
-	struct ipv6hdr *ip6h;
-	struct tcphdr *tcph;
-
 	struct packet_id p_id = { 0 };
 	struct packet_timestamp p_ts = { 0 };
 
-	proto = parse_ethhdr(&nh, data_end, &eth);
+	void *data = (void *)(long)skb->data;
+	void *data_end = (void *)(long)skb->data_end;
 
-	// Parse IPv4/6 header
-	if (proto == bpf_htons(ETH_P_IP)) {
-		p_id.flow.ipv = AF_INET;
-		proto = parse_iphdr(&nh, data_end, &iph);
-	} else if (proto == bpf_htons(ETH_P_IPV6)) {
-		p_id.flow.ipv = AF_INET6;
-		proto = parse_ip6hdr(&nh, data_end, &ip6h);
-	} else
+	if (parse_packet_identifier(data, data_end, true, &p_id,
+				    &p_id.flow.saddr, &p_id.flow.daddr) < 0)
 		goto end;
-
-	// Parse TCP timestamp
-	if (proto != IPPROTO_TCP)
-		goto end;
-	if (parse_tcphdr(&nh, data_end, &tcph) < 0)
-		goto end;
-	if (parse_tcp_ts(tcph, data_end, &tsval, &tsecr) < 0)
-		goto end;
-
-	// We have a TCP timestamp, try adding it to the map
-	p_id.identifier = tsval;
-	if (p_id.flow.ipv == AF_INET) {
-		map_ipv4_to_ipv6(iph->saddr, &p_id.flow.saddr);
-		map_ipv4_to_ipv6(iph->daddr, &p_id.flow.daddr);
-	} else { // IPv6
-		p_id.flow.saddr = ip6h->saddr;
-		p_id.flow.daddr = ip6h->daddr;
-	}
-	p_id.flow.sport = tcph->source;
-	p_id.flow.dport = tcph->dest;
 
 	p_ts.timestamp = bpf_ktime_get_ns(); // or bpf_ktime_get_boot_ns
 	bpf_map_update_elem(&ts_start, &p_id, &p_ts, BPF_NOEXIST);

--- a/pping/pping_kern_tc.c
+++ b/pping/pping_kern_tc.c
@@ -5,8 +5,10 @@
 #include <xdp/parsing_helpers.h>
 
 #include <linux/in.h>
+#include <linux/in6.h>
 #include <linux/if_ether.h>
 #include <linux/ip.h>
+#include <linux/ipv6.h>
 #include <linux/tcp.h>
 
 #include <string.h>
@@ -19,8 +21,8 @@ char _license[] SEC("license") = "GPL";
 #ifdef HAVE_TC_LIBBPF /* detected by configure script in config.mk */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(key_size, sizeof(struct ts_key));
-	__uint(value_size, sizeof(struct ts_timestamp));
+	__uint(key_size, sizeof(struct packet_id));
+	__uint(value_size, sizeof(struct packet_timestamp));
 	__uint(max_entries, 16384);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } ts_start SEC(".maps");
@@ -28,8 +30,8 @@ struct {
 #else
 struct bpf_elf_map SEC("maps") ts_start = {
 	.type = BPF_MAP_TYPE_HASH,
-	.size_key = sizeof(struct ts_key),
-	.size_value = sizeof(struct ts_timestamp),
+	.size_key = sizeof(struct packet_id),
+	.size_value = sizeof(struct packet_timestamp),
 	.max_elem = 16384,
 	.pinning = PIN_GLOBAL_NS,
 };
@@ -43,34 +45,51 @@ int tc_bpf_prog_egress(struct __sk_buff *skb)
 	void *data_end = (void *)(long)skb->data_end;
 
 	int proto = -1;
+	__u32 tsval, tsecr;
+
 	struct hdr_cursor nh = { .pos = data };
 	struct ethhdr *eth;
 	struct iphdr *iph;
+	struct ipv6hdr *ip6h;
 	struct tcphdr *tcph;
 
-	proto = parse_ethhdr(&nh, data_end, &eth);
-	if (bpf_ntohs(proto) != ETH_P_IP)
-		goto end;
-	proto = parse_iphdr(&nh, data_end, &iph);
-	if (proto != IPPROTO_TCP)
-		goto end;
-	proto = parse_tcphdr(&nh, data_end, &tcph);
-	if (proto < 0)
+	struct packet_id p_id = { 0 };
+	struct packet_timestamp p_ts = { 0 };
+
+	proto = bpf_ntohs(parse_ethhdr(&nh, data_end, &eth));
+
+	// Parse IPv4/6 header
+	if (proto == ETH_P_IP) {
+		p_id.flow.ipv = AF_INET;
+		proto = parse_iphdr(&nh, data_end, &iph);
+	} else if (proto == ETH_P_IPV6) {
+		p_id.flow.ipv = AF_INET6;
+		proto = parse_ip6hdr(&nh, data_end, &ip6h);
+	} else
 		goto end;
 
-	__u32 tsval, tsecr;
+	// Parse TCP timestamp
+	if (proto != IPPROTO_TCP)
+		goto end;
+	if (parse_tcphdr(&nh, data_end, &tcph) < 0)
+		goto end;
 	if (parse_tcp_ts(tcph, data_end, &tsval, &tsecr) < 0)
 		goto end;
 
 	// We have a TCP timestamp, try adding it to the map
-	struct ts_key key;
-	fill_ipv4_flow(&(key.flow), iph->saddr, iph->daddr, tcph->source,
-		       tcph->dest);
-	key.tsval = tsval;
+	p_id.identifier = tsval;
+	if (p_id.flow.ipv == AF_INET) {
+		map_ipv4_to_ipv6(iph->saddr, &(p_id.flow.saddr));
+		map_ipv4_to_ipv6(iph->daddr, &(p_id.flow.daddr));
+	} else { // IPv6
+		p_id.flow.saddr = ip6h->saddr;
+		p_id.flow.daddr = ip6h->daddr;
+	}
+	p_id.flow.sport = tcph->source;
+	p_id.flow.dport = tcph->dest;
 
-	struct ts_timestamp ts = { 0 };
-	ts.timestamp = bpf_ktime_get_ns(); // or bpf_ktime_get_boot_ns
-	bpf_map_update_elem(&ts_start, &key, &ts, BPF_NOEXIST);
+	p_ts.timestamp = bpf_ktime_get_ns(); // or bpf_ktime_get_boot_ns
+	bpf_map_update_elem(&ts_start, &p_id, &p_ts, BPF_NOEXIST);
 
 end:
 	return BPF_OK;

--- a/pping/pping_kern_tc.c
+++ b/pping/pping_kern_tc.c
@@ -56,13 +56,13 @@ int tc_bpf_prog_egress(struct __sk_buff *skb)
 	struct packet_id p_id = { 0 };
 	struct packet_timestamp p_ts = { 0 };
 
-	proto = bpf_ntohs(parse_ethhdr(&nh, data_end, &eth));
+	proto = parse_ethhdr(&nh, data_end, &eth);
 
 	// Parse IPv4/6 header
-	if (proto == ETH_P_IP) {
+	if (proto == bpf_htons(ETH_P_IP)) {
 		p_id.flow.ipv = AF_INET;
 		proto = parse_iphdr(&nh, data_end, &iph);
-	} else if (proto == ETH_P_IPV6) {
+	} else if (proto == bpf_htons(ETH_P_IPV6)) {
 		p_id.flow.ipv = AF_INET6;
 		proto = parse_ip6hdr(&nh, data_end, &ip6h);
 	} else
@@ -79,8 +79,8 @@ int tc_bpf_prog_egress(struct __sk_buff *skb)
 	// We have a TCP timestamp, try adding it to the map
 	p_id.identifier = tsval;
 	if (p_id.flow.ipv == AF_INET) {
-		map_ipv4_to_ipv6(iph->saddr, &(p_id.flow.saddr));
-		map_ipv4_to_ipv6(iph->daddr, &(p_id.flow.daddr));
+		map_ipv4_to_ipv6(iph->saddr, &p_id.flow.saddr);
+		map_ipv4_to_ipv6(iph->daddr, &p_id.flow.daddr);
 	} else { // IPv6
 		p_id.flow.saddr = ip6h->saddr;
 		p_id.flow.daddr = ip6h->daddr;

--- a/pping/pping_kern_xdp.c
+++ b/pping/pping_kern_xdp.c
@@ -1,16 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
-#include <xdp/parsing_helpers.h>
-
-#include <linux/in.h>
-#include <linux/in6.h>
-#include <linux/if_ether.h>
-#include <linux/ip.h>
-#include <linux/ipv6.h>
-#include <linux/tcp.h>
-
-#include <string.h>
 
 #include "pping.h"
 #include "pping_helpers.h"
@@ -31,63 +21,25 @@ struct {
 	__uint(value_size, sizeof(__u32));
 } rtt_events SEC(".maps");
 
-// XDP program for parsing TSECR-val from ingress traffic and check for match in map
+// XDP program for parsing identifier in ingress traffic and check for match in map
 SEC(XDP_PROG_SEC)
 int xdp_prog_ingress(struct xdp_md *ctx)
 {
-	void *data = (void *)(long)ctx->data;
-	void *data_end = (void *)(long)ctx->data_end;
-
-	int proto = -1;
-	__u32 tsval, tsecr;
-
-	struct hdr_cursor nh = { .pos = data };
-	struct ethhdr *eth;
-	struct iphdr *iph;
-	struct ipv6hdr *ip6h;
-	struct tcphdr *tcph;
-
 	struct packet_id p_id = { 0 };
 	struct packet_timestamp *p_ts;
 	struct rtt_event event = { 0 };
 
-	proto = bpf_ntohs(parse_ethhdr(&nh, data_end, &eth));
+	void *data = (void *)(long)ctx->data;
+	void *data_end = (void *)(long)ctx->data_end;
 
-	// Parse IPv4/6 header
-	if (proto == ETH_P_IP) {
-		p_id.flow.ipv = AF_INET;
-		proto = parse_iphdr(&nh, data_end, &iph);
-	} else if (proto == ETH_P_IPV6) {
-		p_id.flow.ipv = AF_INET6;
-		proto = parse_ip6hdr(&nh, data_end, &ip6h);
-	} else
+	// saddr and daddr in reverse order of egress (source <--> dest)
+	if (parse_packet_identifier(data, data_end, false, &p_id,
+				    &p_id.flow.daddr, &p_id.flow.saddr) < 0)
 		goto end;
-
-	// Parse TCP timestamp
-	if (proto != IPPROTO_TCP)
-		goto end;
-	if (parse_tcphdr(&nh, data_end, &tcph) < 0)
-		goto end;
-	if (parse_tcp_ts(tcph, data_end, &tsval, &tsecr) < 0)
-		goto end;
-
-	// We have a TCP-timestamp - now we can check if it's in the map
-	p_id.identifier = tsecr;
-	p_id.flow.proto == proto;
-	// Fill in reverse order of egress (dest <--> source)
-	if (p_id.flow.ipv == AF_INET) {
-		map_ipv4_to_ipv6(iph->daddr, &p_id.flow.saddr);
-		map_ipv4_to_ipv6(iph->saddr, &p_id.flow.daddr);
-	} else { // IPv6
-		p_id.flow.saddr = ip6h->daddr;
-		p_id.flow.daddr = ip6h->saddr;
-	}
-	p_id.flow.sport = tcph->dest;
-	p_id.flow.dport = tcph->source;
 
 	p_ts = bpf_map_lookup_elem(&ts_start, &p_id);
 
-	// Only calculate RTT for first packet with matching TSecr
+	// Only calculate RTT for first packet with matching identifer
 	if (p_ts && p_ts->used == 0) {
 		/*
 		 * As used is not set atomically with the lookup, could 
@@ -98,7 +50,8 @@ int xdp_prog_ingress(struct xdp_md *ctx)
 		p_ts->used = 1;
 		// TODO - Optional delete of entry (if identifier is garantued unique)
 
-		memcpy(&event.flow, &p_id.flow, sizeof(struct network_tuple));
+		__builtin_memcpy(&event.flow, &p_id.flow,
+				 sizeof(struct network_tuple));
 		event.rtt = bpf_ktime_get_ns() - p_ts->timestamp;
 		bpf_perf_event_output(ctx, &rtt_events, BPF_F_CURRENT_CPU,
 				      &event, sizeof(event));

--- a/pping/pping_kern_xdp.c
+++ b/pping/pping_kern_xdp.c
@@ -76,8 +76,8 @@ int xdp_prog_ingress(struct xdp_md *ctx)
 	p_id.flow.proto == proto;
 	// Fill in reverse order of egress (dest <--> source)
 	if (p_id.flow.ipv == AF_INET) {
-		map_ipv4_to_ipv6(iph->daddr, &(p_id.flow.saddr));
-		map_ipv4_to_ipv6(iph->saddr, &(p_id.flow.daddr));
+		map_ipv4_to_ipv6(iph->daddr, &p_id.flow.saddr);
+		map_ipv4_to_ipv6(iph->saddr, &p_id.flow.daddr);
 	} else { // IPv6
 		p_id.flow.saddr = ip6h->daddr;
 		p_id.flow.daddr = ip6h->saddr;
@@ -98,8 +98,7 @@ int xdp_prog_ingress(struct xdp_md *ctx)
 		p_ts->used = 1;
 		// TODO - Optional delete of entry (if identifier is garantued unique)
 
-		memcpy(&(event.flow), &(p_id.flow),
-		       sizeof(struct network_tuple));
+		memcpy(&event.flow, &p_id.flow, sizeof(struct network_tuple));
 		event.rtt = bpf_ktime_get_ns() - p_ts->timestamp;
 		bpf_perf_event_output(ctx, &rtt_events, BPF_F_CURRENT_CPU,
 				      &event, sizeof(event));

--- a/pping/pping_kern_xdp.c
+++ b/pping/pping_kern_xdp.c
@@ -32,9 +32,7 @@ int xdp_prog_ingress(struct xdp_md *ctx)
 	void *data = (void *)(long)ctx->data;
 	void *data_end = (void *)(long)ctx->data_end;
 
-	// saddr and daddr in reverse order of egress (source <--> dest)
-	if (parse_packet_identifier(data, data_end, false, &p_id,
-				    &p_id.flow.daddr, &p_id.flow.saddr) < 0)
+	if (parse_packet_identifier(data, data_end, false, &p_id) < 0)
 		goto end;
 
 	p_ts = bpf_map_lookup_elem(&ts_start, &p_id);

--- a/pping/pping_kern_xdp.c
+++ b/pping/pping_kern_xdp.c
@@ -32,7 +32,7 @@ int xdp_prog_ingress(struct xdp_md *ctx)
 
 	pctx.data = (void *)(long)ctx->data;
 	pctx.data_end = (void *)(long)ctx->data_end;
-	pctx.data_end_end = pctx.data_end;
+	pctx.len = pctx.data_end - pctx.data;
 	pctx.nh.pos = pctx.data;
 
 	if (parse_packet_identifier(&pctx, false, &p_id) < 0)

--- a/pping/pping_kern_xdp.c
+++ b/pping/pping_kern_xdp.c
@@ -25,15 +25,15 @@ struct {
 SEC(XDP_PROG_SEC)
 int xdp_prog_ingress(struct xdp_md *ctx)
 {
-	struct parsing_context pctx;
 	struct packet_id p_id = { 0 };
 	struct packet_timestamp *p_ts;
 	struct rtt_event event = { 0 };
-
-	pctx.data = (void *)(long)ctx->data;
-	pctx.data_end = (void *)(long)ctx->data_end;
-	pctx.len = pctx.data_end - pctx.data;
-	pctx.nh.pos = pctx.data;
+	struct parsing_context pctx = {
+		.data = (void *)(long)ctx->data,
+		.data_end = (void *)(long)ctx->data_end,
+		.pkt_len = pctx.data_end - pctx.data,
+		.nh = { .pos = pctx.data },
+	};
 
 	if (parse_packet_identifier(&pctx, false, &p_id) < 0)
 		goto end;

--- a/pping/pping_kern_xdp.c
+++ b/pping/pping_kern_xdp.c
@@ -4,8 +4,10 @@
 #include <xdp/parsing_helpers.h>
 
 #include <linux/in.h>
+#include <linux/in6.h>
 #include <linux/if_ether.h>
 #include <linux/ip.h>
+#include <linux/ipv6.h>
 #include <linux/tcp.h>
 
 #include <string.h>
@@ -17,8 +19,8 @@ char _license[] SEC("license") = "GPL";
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(key_size, sizeof(struct ts_key));
-	__uint(value_size, sizeof(struct ts_timestamp));
+	__uint(key_size, sizeof(struct packet_id));
+	__uint(value_size, sizeof(struct packet_timestamp));
 	__uint(max_entries, 16384);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } ts_start SEC(".maps");
@@ -37,46 +39,68 @@ int xdp_prog_ingress(struct xdp_md *ctx)
 	void *data_end = (void *)(long)ctx->data_end;
 
 	int proto = -1;
+	__u32 tsval, tsecr;
+
 	struct hdr_cursor nh = { .pos = data };
 	struct ethhdr *eth;
 	struct iphdr *iph;
+	struct ipv6hdr *ip6h;
 	struct tcphdr *tcph;
 
-	proto = parse_ethhdr(&nh, data_end, &eth);
-	if (bpf_ntohs(proto) != ETH_P_IP)
-		goto end;
-	proto = parse_iphdr(&nh, data_end, &iph);
-	if (proto != IPPROTO_TCP)
-		goto end;
-	proto = parse_tcphdr(&nh, data_end, &tcph);
-	if (proto < 0)
+	struct packet_id p_id = { 0 };
+	struct packet_timestamp *p_ts;
+	struct rtt_event event = { 0 };
+
+	proto = bpf_ntohs(parse_ethhdr(&nh, data_end, &eth));
+
+	// Parse IPv4/6 header
+	if (proto == ETH_P_IP) {
+		p_id.flow.ipv = AF_INET;
+		proto = parse_iphdr(&nh, data_end, &iph);
+	} else if (proto == ETH_P_IPV6) {
+		p_id.flow.ipv = AF_INET6;
+		proto = parse_ip6hdr(&nh, data_end, &ip6h);
+	} else
 		goto end;
 
-	__u32 tsval, tsecr;
+	// Parse TCP timestamp
+	if (proto != IPPROTO_TCP)
+		goto end;
+	if (parse_tcphdr(&nh, data_end, &tcph) < 0)
+		goto end;
 	if (parse_tcp_ts(tcph, data_end, &tsval, &tsecr) < 0)
 		goto end;
 
 	// We have a TCP-timestamp - now we can check if it's in the map
-	struct ts_key key;
+	p_id.identifier = tsecr;
+	p_id.flow.proto == proto;
 	// Fill in reverse order of egress (dest <--> source)
-	fill_ipv4_flow(&(key.flow), iph->daddr, iph->saddr, tcph->dest,
-		       tcph->source);
-	key.tsval = tsecr;
-	struct ts_timestamp *ts = bpf_map_lookup_elem(&ts_start, &key);
+	if (p_id.flow.ipv == AF_INET) {
+		map_ipv4_to_ipv6(iph->daddr, &(p_id.flow.saddr));
+		map_ipv4_to_ipv6(iph->saddr, &(p_id.flow.daddr));
+	} else { // IPv6
+		p_id.flow.saddr = ip6h->daddr;
+		p_id.flow.daddr = ip6h->saddr;
+	}
+	p_id.flow.sport = tcph->dest;
+	p_id.flow.dport = tcph->source;
+
+	p_ts = bpf_map_lookup_elem(&ts_start, &p_id);
 
 	// Only calculate RTT for first packet with matching TSecr
-	if (ts && ts->used == 0) {
+	if (p_ts && p_ts->used == 0) {
 		/*
 		 * As used is not set atomically with the lookup, could 
 		 * potentially have multiple "first" packets (on different 
 		 * CPUs), but all those should then also have very similar RTT,
 		 * so don't consider it a significant issue
 		 */
-		ts->used = 1;
+		p_ts->used = 1;
+		// TODO - Optional delete of entry (if identifier is garantued unique)
 
-		struct rtt_event event = { 0 };
-		memcpy(&(event.flow), &(key.flow), sizeof(struct ipv4_flow));
-		event.rtt = bpf_ktime_get_ns() - ts->timestamp;
+		memcpy(&(event.flow), &(p_id.flow),
+		       sizeof(struct network_tuple));
+		event.rtt = bpf_ktime_get_ns() - p_ts->timestamp;
 		bpf_perf_event_output(ctx, &rtt_events, BPF_F_CURRENT_CPU,
 				      &event, sizeof(event));
 	}

--- a/pping/pping_kern_xdp.c
+++ b/pping/pping_kern_xdp.c
@@ -25,14 +25,17 @@ struct {
 SEC(XDP_PROG_SEC)
 int xdp_prog_ingress(struct xdp_md *ctx)
 {
+	struct parsing_context pctx;
 	struct packet_id p_id = { 0 };
 	struct packet_timestamp *p_ts;
 	struct rtt_event event = { 0 };
 
-	void *data = (void *)(long)ctx->data;
-	void *data_end = (void *)(long)ctx->data_end;
+	pctx.data = (void *)(long)ctx->data;
+	pctx.data_end = (void *)(long)ctx->data_end;
+	pctx.data_end_end = pctx.data_end;
+	pctx.nh.pos = pctx.data;
 
-	if (parse_packet_identifier(data, data_end, false, &p_id) < 0)
+	if (parse_packet_identifier(&pctx, false, &p_id) < 0)
 		goto end;
 
 	p_ts = bpf_map_lookup_elem(&ts_start, &p_id);


### PR DESCRIPTION
Hi @tohojo,
Been working a little bit on adding IPv6 support to pping and now got it to a working stage. So thought I would start a pull request so you can provide some feedback on it.

I use `struct in6_addr` to store both IPv6 and IPv4 addresses, by mapping IPv4 addresses to the IPv6 range as we've talked about previously. I'm not entierly sure I do the mapping correctly, however as I'm also the one who does the "unmapping" it seems to work. Still, it would be great if you could take a look at that. 

I've also renamed some things to move away a bit from just TCP timestamps and be more general, so that pping can be extended to support different protocols in the future (as we've also talked about). There's still much more do be done in this area though, and my focus has mainly been on adding IPv6 support. I've therefore kept the code in `pping_kern*` quite similar to how it was for now, even if it means a fair bit of repetition.