### PR TITLE
Pping better output

### DIFF
--- a/lib/util/json_writer.c
+++ b/lib/util/json_writer.c
@@ -1,0 +1,392 @@
+/* SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause) */
+
+/* Copied from iproute2/lib/json_writer.c */
+
+/*
+ * Simple streaming JSON writer
+ *
+ * This takes care of the annoying bits of JSON syntax like the commas
+ * after elements
+ *
+ * Authors:	Stephen Hemminger <stephen@networkplumber.org>
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <assert.h>
+#include <malloc.h>
+#include <inttypes.h>
+#include <stdint.h>
+
+#include "json_writer.h"
+
+struct json_writer {
+	FILE		*out;	/* output file */
+	unsigned	depth;  /* nesting */
+	bool		pretty; /* optional whitepace */
+	char		sep;	/* either nul or comma */
+};
+
+/* indentation for pretty print */
+static void jsonw_indent(json_writer_t *self)
+{
+	unsigned i;
+	for (i = 0; i < self->depth; ++i)
+		fputs("    ", self->out);
+}
+
+/* end current line and indent if pretty printing */
+static void jsonw_eol(json_writer_t *self)
+{
+	if (!self->pretty)
+		return;
+
+	putc('\n', self->out);
+	jsonw_indent(self);
+}
+
+/* If current object is not empty print a comma */
+static void jsonw_eor(json_writer_t *self)
+{
+	if (self->sep != '\0')
+		putc(self->sep, self->out);
+	self->sep = ',';
+}
+
+
+/* Output JSON encoded string */
+/* Handles C escapes, does not do Unicode */
+static void jsonw_puts(json_writer_t *self, const char *str)
+{
+	putc('"', self->out);
+	for (; *str; ++str)
+		switch (*str) {
+		case '\t':
+			fputs("\\t", self->out);
+			break;
+		case '\n':
+			fputs("\\n", self->out);
+			break;
+		case '\r':
+			fputs("\\r", self->out);
+			break;
+		case '\f':
+			fputs("\\f", self->out);
+			break;
+		case '\b':
+			fputs("\\b", self->out);
+			break;
+		case '\\':
+			fputs("\\\\", self->out);
+			break;
+		case '"':
+			fputs("\\\"", self->out);
+			break;
+		case '\'':
+			fputs("\\\'", self->out);
+			break;
+		default:
+			putc(*str, self->out);
+		}
+	putc('"', self->out);
+}
+
+/* Create a new JSON stream */
+json_writer_t *jsonw_new(FILE *f)
+{
+	json_writer_t *self = malloc(sizeof(*self));
+	if (self) {
+		self->out = f;
+		self->depth = 0;
+		self->pretty = false;
+		self->sep = '\0';
+	}
+	return self;
+}
+
+/* End output to JSON stream */
+void jsonw_destroy(json_writer_t **self_p)
+{
+	json_writer_t *self = *self_p;
+
+	assert(self->depth == 0);
+	fputs("\n", self->out);
+	fflush(self->out);
+	free(self);
+	*self_p = NULL;
+}
+
+void jsonw_pretty(json_writer_t *self, bool on)
+{
+	self->pretty = on;
+}
+
+/* Basic blocks */
+static void jsonw_begin(json_writer_t *self, int c)
+{
+	jsonw_eor(self);
+	putc(c, self->out);
+	++self->depth;
+	self->sep = '\0';
+}
+
+static void jsonw_end(json_writer_t *self, int c)
+{
+	assert(self->depth > 0);
+
+	--self->depth;
+	if (self->sep != '\0')
+		jsonw_eol(self);
+	putc(c, self->out);
+	self->sep = ',';
+}
+
+
+/* Add a JSON property name */
+void jsonw_name(json_writer_t *self, const char *name)
+{
+	jsonw_eor(self);
+	jsonw_eol(self);
+	self->sep = '\0';
+	jsonw_puts(self, name);
+	putc(':', self->out);
+	if (self->pretty)
+		putc(' ', self->out);
+}
+
+__attribute__((format(printf, 2, 3)))
+void jsonw_printf(json_writer_t *self, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	jsonw_eor(self);
+	vfprintf(self->out, fmt, ap);
+	va_end(ap);
+}
+
+/* Collections */
+void jsonw_start_object(json_writer_t *self)
+{
+	jsonw_begin(self, '{');
+}
+
+void jsonw_end_object(json_writer_t *self)
+{
+	jsonw_end(self, '}');
+}
+
+void jsonw_start_array(json_writer_t *self)
+{
+	jsonw_begin(self, '[');
+	if (self->pretty)
+		putc(' ', self->out);
+}
+
+void jsonw_end_array(json_writer_t *self)
+{
+	if (self->pretty && self->sep)
+		putc(' ', self->out);
+	self->sep = '\0';
+	jsonw_end(self, ']');
+}
+
+/* JSON value types */
+void jsonw_string(json_writer_t *self, const char *value)
+{
+	jsonw_eor(self);
+	jsonw_puts(self, value);
+}
+
+void jsonw_bool(json_writer_t *self, bool val)
+{
+	jsonw_printf(self, "%s", val ? "true" : "false");
+}
+
+void jsonw_null(json_writer_t *self)
+{
+	jsonw_printf(self, "null");
+}
+
+void jsonw_float(json_writer_t *self, double num)
+{
+	jsonw_printf(self, "%g", num);
+}
+
+void jsonw_hhu(json_writer_t *self, unsigned char num)
+{
+	jsonw_printf(self, "%hhu", num);
+}
+
+void jsonw_hu(json_writer_t *self, unsigned short num)
+{
+	jsonw_printf(self, "%hu", num);
+}
+
+void jsonw_uint(json_writer_t *self, unsigned int num)
+{
+	jsonw_printf(self, "%u", num);
+}
+
+void jsonw_u64(json_writer_t *self, uint64_t num)
+{
+	jsonw_printf(self, "%"PRIu64, num);
+}
+
+void jsonw_xint(json_writer_t *self, uint64_t num)
+{
+	jsonw_printf(self, "%"PRIx64, num);
+}
+
+void jsonw_luint(json_writer_t *self, unsigned long num)
+{
+	jsonw_printf(self, "%lu", num);
+}
+
+void jsonw_lluint(json_writer_t *self, unsigned long long num)
+{
+	jsonw_printf(self, "%llu", num);
+}
+
+void jsonw_int(json_writer_t *self, int num)
+{
+	jsonw_printf(self, "%d", num);
+}
+
+void jsonw_s64(json_writer_t *self, int64_t num)
+{
+	jsonw_printf(self, "%"PRId64, num);
+}
+
+/* Basic name/value objects */
+void jsonw_string_field(json_writer_t *self, const char *prop, const char *val)
+{
+	jsonw_name(self, prop);
+	jsonw_string(self, val);
+}
+
+void jsonw_bool_field(json_writer_t *self, const char *prop, bool val)
+{
+	jsonw_name(self, prop);
+	jsonw_bool(self, val);
+}
+
+void jsonw_float_field(json_writer_t *self, const char *prop, double val)
+{
+	jsonw_name(self, prop);
+	jsonw_float(self, val);
+}
+
+void jsonw_uint_field(json_writer_t *self, const char *prop, unsigned int num)
+{
+	jsonw_name(self, prop);
+	jsonw_uint(self, num);
+}
+
+void jsonw_u64_field(json_writer_t *self, const char *prop, uint64_t num)
+{
+	jsonw_name(self, prop);
+	jsonw_u64(self, num);
+}
+
+void jsonw_xint_field(json_writer_t *self, const char *prop, uint64_t num)
+{
+	jsonw_name(self, prop);
+	jsonw_xint(self, num);
+}
+
+void jsonw_hhu_field(json_writer_t *self, const char *prop, unsigned char num)
+{
+	jsonw_name(self, prop);
+	jsonw_hhu(self, num);
+}
+
+void jsonw_hu_field(json_writer_t *self, const char *prop, unsigned short num)
+{
+	jsonw_name(self, prop);
+	jsonw_hu(self, num);
+}
+
+void jsonw_luint_field(json_writer_t *self,
+			const char *prop,
+			unsigned long num)
+{
+	jsonw_name(self, prop);
+	jsonw_luint(self, num);
+}
+
+void jsonw_lluint_field(json_writer_t *self,
+			const char *prop,
+			unsigned long long num)
+{
+	jsonw_name(self, prop);
+	jsonw_lluint(self, num);
+}
+
+void jsonw_int_field(json_writer_t *self, const char *prop, int num)
+{
+	jsonw_name(self, prop);
+	jsonw_int(self, num);
+}
+
+void jsonw_s64_field(json_writer_t *self, const char *prop, int64_t num)
+{
+	jsonw_name(self, prop);
+	jsonw_s64(self, num);
+}
+
+void jsonw_null_field(json_writer_t *self, const char *prop)
+{
+	jsonw_name(self, prop);
+	jsonw_null(self);
+}
+
+#ifdef TEST
+int main(int argc, char **argv)
+{
+	json_writer_t *wr = jsonw_new(stdout);
+
+	jsonw_start_object(wr);
+	jsonw_pretty(wr, true);
+	jsonw_name(wr, "Vyatta");
+	jsonw_start_object(wr);
+	jsonw_string_field(wr, "url", "http://vyatta.com");
+	jsonw_uint_field(wr, "downloads", 2000000ul);
+	jsonw_float_field(wr, "stock", 8.16);
+
+	jsonw_name(wr, "ARGV");
+	jsonw_start_array(wr);
+	while (--argc)
+		jsonw_string(wr, *++argv);
+	jsonw_end_array(wr);
+
+	jsonw_name(wr, "empty");
+	jsonw_start_array(wr);
+	jsonw_end_array(wr);
+
+	jsonw_name(wr, "NIL");
+	jsonw_start_object(wr);
+	jsonw_end_object(wr);
+
+	jsonw_null_field(wr, "my_null");
+
+	jsonw_name(wr, "special chars");
+	jsonw_start_array(wr);
+	jsonw_string_field(wr, "slash", "/");
+	jsonw_string_field(wr, "newline", "\n");
+	jsonw_string_field(wr, "tab", "\t");
+	jsonw_string_field(wr, "ff", "\f");
+	jsonw_string_field(wr, "quote", "\"");
+	jsonw_string_field(wr, "tick", "\'");
+	jsonw_string_field(wr, "backslash", "\\");
+	jsonw_end_array(wr);
+
+	jsonw_end_object(wr);
+
+	jsonw_end_object(wr);
+	jsonw_destroy(&wr);
+	return 0;
+}
+
+#endif

--- a/lib/util/json_writer.h
+++ b/lib/util/json_writer.h
@@ -1,0 +1,79 @@
+/* SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause) */
+
+/* Copied from iproute2/include/json_writer.h */
+
+/*
+ * Simple streaming JSON writer
+ *
+ * This takes care of the annoying bits of JSON syntax like the commas
+ * after elements
+ *
+ * Authors:	Stephen Hemminger <stephen@networkplumber.org>
+ */
+
+#ifndef _JSON_WRITER_H_
+#define _JSON_WRITER_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Opaque class structure */
+typedef struct json_writer json_writer_t;
+
+/* Create a new JSON stream */
+json_writer_t *jsonw_new(FILE *f);
+/* End output to JSON stream */
+void jsonw_destroy(json_writer_t **self_p);
+
+/* Cause output to have pretty whitespace */
+void jsonw_pretty(json_writer_t *self, bool on);
+
+/* Add property name */
+void jsonw_name(json_writer_t *self, const char *name);
+
+/* Add value  */
+__attribute__((format(printf, 2, 3)))
+void jsonw_printf(json_writer_t *self, const char *fmt, ...);
+void jsonw_string(json_writer_t *self, const char *value);
+void jsonw_bool(json_writer_t *self, bool value);
+void jsonw_float(json_writer_t *self, double number);
+void jsonw_float_fmt(json_writer_t *self, const char *fmt, double num);
+void jsonw_uint(json_writer_t *self, unsigned int number);
+void jsonw_u64(json_writer_t *self, uint64_t number);
+void jsonw_xint(json_writer_t *self, uint64_t number);
+void jsonw_hhu(json_writer_t *self, unsigned char num);
+void jsonw_hu(json_writer_t *self, unsigned short number);
+void jsonw_int(json_writer_t *self, int number);
+void jsonw_s64(json_writer_t *self, int64_t number);
+void jsonw_null(json_writer_t *self);
+void jsonw_luint(json_writer_t *self, unsigned long num);
+void jsonw_lluint(json_writer_t *self, unsigned long long num);
+
+/* Useful Combinations of name and value */
+void jsonw_string_field(json_writer_t *self, const char *prop, const char *val);
+void jsonw_bool_field(json_writer_t *self, const char *prop, bool value);
+void jsonw_float_field(json_writer_t *self, const char *prop, double num);
+void jsonw_uint_field(json_writer_t *self, const char *prop, unsigned int num);
+void jsonw_u64_field(json_writer_t *self, const char *prop, uint64_t num);
+void jsonw_xint_field(json_writer_t *self, const char *prop, uint64_t num);
+void jsonw_hhu_field(json_writer_t *self, const char *prop, unsigned char num);
+void jsonw_hu_field(json_writer_t *self, const char *prop, unsigned short num);
+void jsonw_int_field(json_writer_t *self, const char *prop, int num);
+void jsonw_s64_field(json_writer_t *self, const char *prop, int64_t num);
+void jsonw_null_field(json_writer_t *self, const char *prop);
+void jsonw_luint_field(json_writer_t *self, const char *prop,
+			unsigned long num);
+void jsonw_lluint_field(json_writer_t *self, const char *prop,
+			unsigned long long num);
+
+/* Collections */
+void jsonw_start_object(json_writer_t *self);
+void jsonw_end_object(json_writer_t *self);
+
+void jsonw_start_array(json_writer_t *self);
+void jsonw_end_array(json_writer_t *self);
+
+/* Override default exception handling */
+typedef void (jsonw_err_handler_fn)(const char *);
+
+#endif /* _JSON_WRITER_H_ */

--- a/lib/util/util.mk
+++ b/lib/util/util.mk
@@ -1,2 +1,2 @@
 # list of objects in this directory
-UTIL_OBJS :=
+UTIL_OBJS := json_writer.o

--- a/pping/Makefile
+++ b/pping/Makefile
@@ -3,7 +3,7 @@
 USER_TARGETS   := pping
 BPF_TARGETS    := pping_kern
 
-LDFLAGS    += -pthread
+LDLIBS     += -pthread
 EXTRA_DEPS += pping.h
 
 LIB_DIR = ../lib

--- a/pping/README.md
+++ b/pping/README.md
@@ -151,12 +151,18 @@ being reported for the same identifier, but if they are processed concurrently
 these RTTs should be very similar, so would mainly result in over-reporting
 rather than reporting incorrect RTTs.
 
-#### Updating flow min-RTT
-Whenever the XDP/ingress program calculates an RTT, it will check if this is the
-lowest RTT seen so far for the flow. If multiple RTTs are calculated
-concurrently, then several could pass this check concurrently and there may be a
-lost update. It should only be possible for multiple RTTs to be calculated
-concurrently in case either the [timestamp rate-limit was
+#### Updating flow statistics
+Both the tc/egress and XDP/ingress programs will try to update some flow
+statistics each time they successfully parse a packet with an
+identifier. Specifically, they'll update the number of packets and bytes
+sent/received. This is not done in an atomic fashion, so there could potentially
+be some lost updates resulting an underestimate.
+
+Furthermore, whenever the XDP/ingress program calculates an RTT, it will check
+if this is the lowest RTT seen so far for the flow. If multiple RTTs are
+calculated concurrently, then several could pass this check concurrently and
+there may be a lost update. It should only be possible for multiple RTTs to be
+calculated concurrently in case either the [timestamp rate-limit was
 bypassed](#Rate-limiting new timestamps) or [multiple packets managed to match
 against the same timestamp](#Matching against stored timestamps).
 

--- a/pping/TODO.md
+++ b/pping/TODO.md
@@ -38,10 +38,6 @@
     unnecessarily large, which slows down the cleaning and may block
     new entries
 - [ ] Use libxdp to load XDP program
-- [ ] Add option for machine-readable output (as original pping)
-  - It may be a good idea to keep the same format as original pping,
-    so that tools such as [ppviz](https://github.com/pollere/ppviz)
-    works for both pping implementations.
 - [ ] Add support for other hooks
   - Ex TC-BFP on ingress instead of XDP?
 
@@ -58,4 +54,9 @@
 - [x] Add IPv6 support
 - [x] Refactor to support easy addition of other protocols
 - [x] Load tc-bpf program with libbpf (only attach it with tc)
+- [x] Switch to libbpf TC-BPF API for attaching the TC-BPF program
+- [x] Add option for machine-readable output (as original pping)
+  - It may be a good idea to keep the same format as original pping,
+    so that tools such as [ppviz](https://github.com/pollere/ppviz)
+    works for both pping implementations.
 - [x] Add timestamps to output (as original pping)

--- a/pping/TODO.md
+++ b/pping/TODO.md
@@ -25,7 +25,7 @@
   - [ ] Could potentially include keeping track of average RTT, which
         may be useful for some decisions (ex. how often to sample,
         when entry can be removed etc)
-  - [ ] Could potentially include keeping track of minimum RTT (as
+  - [x] Could potentially include keeping track of minimum RTT (as
         done by the original pping), ex. to track bufferbloat
   - [ ] Could potentially include keeping track of if flow is
         bi-directional
@@ -42,7 +42,6 @@
   - It may be a good idea to keep the same format as original pping,
     so that tools such as [ppviz](https://github.com/pollere/ppviz)
     works for both pping implementations.
-- [ ] Add timestamps to output (as original pping)
 - [ ] Add support for other hooks
   - Ex TC-BFP on ingress instead of XDP?
 
@@ -59,3 +58,4 @@
 - [x] Add IPv6 support
 - [x] Refactor to support easy addition of other protocols
 - [x] Load tc-bpf program with libbpf (only attach it with tc)
+- [x] Add timestamps to output (as original pping)

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -488,8 +488,8 @@ static __u64 convert_monotonic_to_realtime(__u64 monotonic_time)
  * Wrapper around inet_ntop designed to handle the "bug" that mapped IPv4
  * addresses are formated as IPv6 addresses for AF_INET6
  */
-static int format_ip_address(int af, const struct in6_addr *addr, char *buf,
-			     size_t size)
+static int format_ip_address(char *buf, size_t size, int af,
+			     const struct in6_addr *addr)
 {
 	if (af == AF_INET)
 		return inet_ntop(af, &addr->s6_addr[12],
@@ -526,8 +526,8 @@ static void print_rtt_event_standard(void *ctx, int cpu, void *data,
 	__u64 ts = convert_monotonic_to_realtime(e->timestamp);
 	time_t ts_s = ts / NS_PER_SECOND;
 
-	format_ip_address(e->flow.ipv, &e->flow.saddr.ip, saddr, sizeof(saddr));
-	format_ip_address(e->flow.ipv, &e->flow.daddr.ip, daddr, sizeof(daddr));
+	format_ip_address(saddr, sizeof(saddr), e->flow.ipv, &e->flow.saddr.ip);
+	format_ip_address(daddr, sizeof(daddr), e->flow.ipv, &e->flow.daddr.ip);
 	strftime(timestr, sizeof(timestr), "%H:%M:%S", localtime(&ts_s));
 
 	printf("%s.%09llu %llu.%06llu ms %llu.%06llu ms %s:%d+%s:%d\n", timestr,
@@ -544,8 +544,8 @@ static void print_rtt_event_ppviz(void *ctx, int cpu, void *data,
 	char daddr[INET6_ADDRSTRLEN];
 	__u64 time = convert_monotonic_to_realtime(e->timestamp);
 
-	format_ip_address(e->flow.ipv, &e->flow.saddr.ip, saddr, sizeof(saddr));
-	format_ip_address(e->flow.ipv, &e->flow.daddr.ip, daddr, sizeof(daddr));
+	format_ip_address(saddr, sizeof(saddr), e->flow.ipv, &e->flow.saddr.ip);
+	format_ip_address(daddr, sizeof(daddr), e->flow.ipv, &e->flow.daddr.ip);
 
 	printf("%llu.%09llu %llu.%09llu %llu.%09llu %s:%d+%s:%d\n",
 	       time / NS_PER_SECOND, time % NS_PER_SECOND,
@@ -562,8 +562,8 @@ static void print_rtt_event_json(void *ctx, int cpu, void *data,
 	char daddr[INET6_ADDRSTRLEN];
 	__u64 time = convert_monotonic_to_realtime(e->timestamp);
 
-	format_ip_address(e->flow.ipv, &e->flow.saddr.ip, saddr, sizeof(saddr));
-	format_ip_address(e->flow.ipv, &e->flow.daddr.ip, daddr, sizeof(daddr));
+	format_ip_address(saddr, sizeof(saddr), e->flow.ipv, &e->flow.saddr.ip);
+	format_ip_address(daddr, sizeof(daddr), e->flow.ipv, &e->flow.daddr.ip);
 
 	if (json_started) {
 		printf(",");

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -574,12 +574,15 @@ static void print_rtt_event_json(void *ctx, int cpu, void *data,
 
 	printf("\n{\"timestamp\":%llu.%09llu, \"rtt\":%llu.%09llu, "
 	       "\"min_rtt\":%llu.%09llu, \"src_ip\":\"%s\", \"src_port\":%d, "
-	       "\"dest_ip\":\"%s\", \"dest_port\":%d, \"protocol\":\"%s\"}",
+	       "\"dest_ip\":\"%s\", \"dest_port\":%d, \"protocol\":\"%s\", "
+	       "\"sent_pkts\":%llu, \"sent_bytes\":%llu, \"rec_pkts\":%llu, "
+	       "\"rec_bytes\":%llu }",
 	       time / NS_PER_SECOND, time % NS_PER_SECOND,
 	       e->rtt / NS_PER_SECOND, e->rtt % NS_PER_SECOND,
 	       e->min_rtt / NS_PER_SECOND, e->min_rtt % NS_PER_SECOND, saddr,
 	       ntohs(e->flow.saddr.port), daddr, ntohs(e->flow.daddr.port),
-	       proto_to_str(e->flow.proto));
+	       proto_to_str(e->flow.proto), e->sent_pkts, e->sent_bytes,
+	       e->rec_pkts, e->rec_bytes);
 }
 
 static void end_json_output(void)

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -78,6 +78,7 @@ struct pping_config {
 	int ifindex;
 	char ifname[IF_NAMESIZE];
 	bool json_format;
+	bool machine_format;
 	bool force;
 };
 
@@ -91,6 +92,7 @@ static const struct option long_options[] = {
 	{ "force",            no_argument,       NULL, 'f' }, // Detach any existing XDP program on interface
 	{ "cleanup-interval", required_argument, NULL, 'c' }, // Map cleaning interval in s
 	{ "json",             no_argument,       NULL, 'j' }, // Output in JSON format
+	{ "machine-friendly", no_argument,       NULL, 'm' }, // Ouput in Kathie's "machine friendly" format
 	{ 0, 0, NULL, 0 }
 };
 
@@ -142,7 +144,7 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 
 	config->ifindex = 0;
 
-	while ((opt = getopt_long(argc, argv, "hfji:r:c:", long_options,
+	while ((opt = getopt_long(argc, argv, "hfjmi:r:c:", long_options,
 				  NULL)) != -1) {
 		switch (opt) {
 		case 'i':
@@ -181,6 +183,9 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 			break;
 		case 'j':
 			config->json_format = true;
+			break;
+		case 'm':
+			config->machine_format = true;
 			break;
 		case 'f':
 			config->force = true;
@@ -525,6 +530,23 @@ static void print_rtt_event_standard(void *ctx, int cpu, void *data,
 	       ntohs(e->flow.saddr.port), daddr, ntohs(e->flow.daddr.port));
 }
 
+static void print_rtt_event_mf(void *ctx, int cpu, void *data, __u32 data_size)
+{
+	const struct rtt_event *e = data;
+	char saddr[INET6_ADDRSTRLEN];
+	char daddr[INET6_ADDRSTRLEN];
+	__u64 time = convert_monotonic_to_realtime(e->timestamp);
+
+	format_ip_address(e->flow.ipv, &e->flow.saddr.ip, saddr, sizeof(saddr));
+	format_ip_address(e->flow.ipv, &e->flow.daddr.ip, daddr, sizeof(daddr));
+
+	printf("%llu.%09llu %llu.%09llu %llu.%09llu %s:%d+%s:%d\n",
+	       time / NS_PER_SECOND, time % NS_PER_SECOND,
+	       e->rtt / NS_PER_SECOND, e->rtt % NS_PER_SECOND,
+	       e->min_rtt / NS_PER_SECOND, e->min_rtt, saddr,
+	       ntohs(e->flow.saddr.port), daddr, ntohs(e->flow.daddr.port));
+}
+
 static void print_rtt_event_json(void *ctx, int cpu, void *data,
 				 __u32 data_size)
 {
@@ -687,6 +709,7 @@ int main(int argc, char *argv[])
 		.rtt_map = "rtt_events",
 		.xdp_flags = XDP_FLAGS_UPDATE_IF_NOEXIST,
 		.json_format = false,
+		.machine_format = false,
 		.force = false,
 	};
 
@@ -718,8 +741,12 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
+	if (config.json_format && config.machine_format)
+		fprintf(stderr, "Cannot output in both JSON and \"machine-friendly\" format, will use JSON\n");
 	if (config.json_format)
 		pb_opts.sample_cb = print_rtt_event_json;
+	else if (config.machine_format)
+		pb_opts.sample_cb = print_rtt_event_mf;
 
 	err = load_attach_bpfprogs(&obj, &config, &tc_attached, &xdp_attached);
 	if (err) {

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -41,6 +41,10 @@ struct network_tuple {
 struct flow_state {
 	__u64 min_rtt;
 	__u64 last_timestamp;
+	__u64 sent_pkts;
+	__u64 sent_bytes;
+	__u64 rec_pkts;
+	__u64 rec_bytes;
 	__u32 last_id;
 	__u32 reserved;
 };
@@ -53,6 +57,10 @@ struct packet_id {
 struct rtt_event {
 	__u64 rtt;
 	__u64 min_rtt;
+	__u64 sent_pkts;
+	__u64 sent_bytes;
+	__u64 rec_pkts;
+	__u64 rec_bytes;
 	__u64 timestamp;
 	struct network_tuple flow;
 	__u32 reserved;

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -39,6 +39,7 @@ struct network_tuple {
 };
 
 struct flow_state {
+	__u64 min_rtt;
 	__u64 last_timestamp;
 	__u32 last_id;
 	__u32 reserved;
@@ -51,6 +52,8 @@ struct packet_id {
 
 struct rtt_event {
 	__u64 rtt;
+	__u64 min_rtt;
+	__u64 timestamp;
 	struct network_tuple flow;
 	__u32 reserved;
 };

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -14,12 +14,12 @@
 #define EVENT_TYPE_RTT 2
 
 enum __attribute__((__packed__)) flow_event_type {
-	FLOW_EVENT_UNSPECIFIED,
+	FLOW_EVENT_NONE,
 	FLOW_EVENT_OPENING,
 	FLOW_EVENT_CLOSING
 };
 
-enum __attribute__ ((__packed__)) flow_event_reason {
+enum __attribute__((__packed__)) flow_event_reason {
 	EVENT_REASON_SYN,
 	EVENT_REASON_SYN_ACK,
 	EVENT_REASON_FIRST_OBS_PCKT,
@@ -27,6 +27,12 @@ enum __attribute__ ((__packed__)) flow_event_reason {
 	EVENT_REASON_FIN_ACK,
 	EVENT_REASON_RST,
 	EVENT_REASON_FLOW_TIMEOUT
+};
+
+enum __attribute__((__packed__)) flow_event_source {
+	EVENT_SOURCE_EGRESS,
+	EVENT_SOURCE_INGRESS,
+	EVENT_SOURCE_USERSPACE
 };
 
 struct bpf_config {
@@ -97,6 +103,11 @@ struct rtt_event {
 	__u32 reserved;
 };
 
+struct flow_event_info {
+	enum flow_event_type event;
+	enum flow_event_reason reason;
+};
+
 /*
  * A flow event message that can be passed from the bpf-programs to user-space.
  * The initial event_type memeber is used to allow multiplexing between
@@ -107,9 +118,8 @@ struct flow_event {
 	__u64 event_type;
 	__u64 timestamp;
 	struct network_tuple flow;
-	enum flow_event_type event;
-	enum flow_event_reason reason;
-	bool from_egress;
+	struct flow_event_info event_info;
+	enum flow_event_source source;
 	__u8 reserved;
 };
 

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -123,4 +123,10 @@ struct flow_event {
 	__u8 reserved;
 };
 
+union pping_event {
+	__u64 event_type;
+	struct rtt_event rtt_event;
+	struct flow_event flow_event;
+};
+
 #endif

--- a/pping/pping_kern.c
+++ b/pping/pping_kern.c
@@ -197,16 +197,16 @@ static int parse_packet_identifier(struct parsing_context *ctx,
 	// Parse IPv4/6 header
 	if (proto == bpf_htons(ETH_P_IP)) {
 		p_id->flow.ipv = AF_INET;
-		proto = parse_iphdr(&ctx->nh, ctx->data_end, &iph);
+		p_id->flow.proto = parse_iphdr(&ctx->nh, ctx->data_end, &iph);
 	} else if (proto == bpf_htons(ETH_P_IPV6)) {
 		p_id->flow.ipv = AF_INET6;
-		proto = parse_ip6hdr(&ctx->nh, ctx->data_end, &ip6h);
+		p_id->flow.proto = parse_ip6hdr(&ctx->nh, ctx->data_end, &ip6h);
 	} else {
 		return -1;
 	}
 
 	// Add new protocols here
-	if (proto == IPPROTO_TCP) {
+	if (p_id->flow.proto == IPPROTO_TCP) {
 		err = parse_tcp_identifier(ctx, &saddr->port, &daddr->port,
 					   flow_closing, &p_id->identifier);
 		if (err)

--- a/pping/pping_kern.c
+++ b/pping/pping_kern.c
@@ -265,36 +265,11 @@ int pping_egress(struct __sk_buff *skb)
 	}
 
 	// Check if identfier is new
-	/* The gap between checking and updating last_id may cause concurrency
-	 * issues where multiple packets may simultaneously think they are the
-	 * first with a new identifier. As long as all of the identifiers are
-	 * the same though, only one should be able to create a timestamp entry.
-
-	 * A bigger issue is that older identifiers (for example due to
-         * out-of-order packets) may pass this check and update the current
-	 * identifier to an old one. This means that both the packet with the
-	 * old identifier itself as well the next packet with the current
-	 * identifier may be considered packets with new identifiers (even if
-	 * both have been seen before). For TCP timestamps this could be
-	 * prevented by changing the check to '>=' instead, but it may not be
-	 * suitable for other protocols, such as QUIC and its spinbit.
-	 *
-	 * For now, just hope that the rate limit saves us from creating an
-	 * incorrect timestamp. That may however also fail, either due to the
-	 * to it happening in a time it's not limited by rate sampling, or
-	 * because of rate check failing due to concurrency issues.
-	 */
 	if (f_state->last_id == p_id.identifier)
 		goto out;
 	f_state->last_id = p_id.identifier;
 
 	// Check rate-limit
-	/*
-	 * The window between checking and updating last_timestamp may cause
-	 * concurrency issues, where multiple packets simultaneously pass the
-	 * rate limit. However, as long as they have the same identifier, only
-	 * a single timestamp entry should successfully be created.
-	 */
 	p_ts = bpf_ktime_get_ns(); // or bpf_ktime_get_boot_ns
 	if (p_ts < f_state->last_timestamp ||
 	    p_ts - f_state->last_timestamp < config.rate_limit)
@@ -341,14 +316,11 @@ int pping_ingress(struct xdp_md *ctx)
 
 	event.rtt = now - *p_ts;
 	event.timestamp = now;
-	/*
-	 * Attempt to delete timestamp entry as soon as RTT is calculated.
-	 * But could have potential concurrency issue where multiple packets
-	 * manage to match against the identifier before it can be deleted.
-	 */
+
+	// Delete timestamp entry as soon as RTT is calculated
 	bpf_map_delete_elem(&packet_ts, &p_id);
 
-	// Update flow's min-RTT, may have concurrency issues
+	// Update flow's min-RTT
 	f_state = bpf_map_lookup_elem(&flow_state, &p_id.flow);
 	if (!f_state)
 		goto validflow_out;
@@ -358,6 +330,7 @@ int pping_ingress(struct xdp_md *ctx)
 
 	event.min_rtt = f_state->min_rtt;
 
+	// Push event to perf-buffer
 	__builtin_memcpy(&event.flow, &p_id.flow, sizeof(struct network_tuple));
 	bpf_perf_event_output(ctx, &rtt_events, BPF_F_CURRENT_CPU, &event,
 			      sizeof(event));


### PR DESCRIPTION
These commits update the standard output format to be equivalent with Kathie's pping standard format, which means it adds a timestamp (pushed from the XDP program) and min-RTT (adds in-kernel tracking of minimum RTT for each flow). Furthermore, I've added a simple JSON format as well as Kathie's "machine friendly" format (used by ppviz).

TODOs:
- Currently the program my report incorrect minimum-RTT if the tc program deletes the flow-information before the XDP program can calculate the RTT of a packet from that flow. Couple of options for fixes would be to only attempt to delete flow-information from the XDP program, or include the current min-RTT into the stored packet timestamp. 
- Update `README` and `TODO`