### PR TITLE
BPF example with ktrace and CO-RE

### DIFF
--- a/headers/vmlinux/arch/arm64/vmlinux.h
+++ b/headers/vmlinux/arch/arm64/vmlinux.h
@@ -1,0 +1,38 @@
+#ifndef __VMLINUX_ARCH_ARM64_H__
+#define __VMLINUX_ARCH_ARM64_H__
+
+#ifdef __BPF_TRACING_H__
+/* Expected include <bpf/bpf_tracing.h> */
+#ifndef bpf_target_defined
+#warning "Tracing need __TARGET_ARCH_arm64 defined"
+#endif
+#endif /*  __BPF_TRACING_H__ */
+
+struct user_pt_regs {
+	__u64 regs[31];
+	__u64 sp;
+	__u64 pc;
+	__u64 pstate;
+};
+
+struct pt_regs {
+	union {
+		struct user_pt_regs user_regs;
+		struct {
+			u64 regs[31];
+			u64 sp;
+			u64 pc;
+			u64 pstate;
+		};
+	};
+	u64 orig_x0;
+	s32 syscallno;
+	u32 unused2;
+	u64 orig_addr_limit;
+	u64 pmr_save;
+	u64 stackframe[2];
+	u64 lockdep_hardirqs;
+	u64 exit_rcu;
+};
+
+#endif /* __VMLINUX_ARCH_ARM64_H__ */

--- a/headers/vmlinux/arch/powerpc/vmlinux.h
+++ b/headers/vmlinux/arch/powerpc/vmlinux.h
@@ -1,0 +1,55 @@
+#ifndef __VMLINUX_ARCH_POWERPC_H__
+#define __VMLINUX_ARCH_POWERPC_H__
+
+#ifdef __BPF_TRACING_H__
+/* Expected include <bpf/bpf_tracing.h> */
+#ifndef bpf_target_defined
+#warning "Tracing need __TARGET_ARCH_powerpc defined"
+#endif
+#endif /*  __BPF_TRACING_H__ */
+
+struct user_pt_regs {
+	long unsigned int gpr[32];
+	long unsigned int nip;
+	long unsigned int msr;
+	long unsigned int orig_gpr3;
+	long unsigned int ctr;
+	long unsigned int link;
+	long unsigned int xer;
+	long unsigned int ccr;
+	long unsigned int softe;
+	long unsigned int trap;
+	long unsigned int dar;
+	long unsigned int dsisr;
+	long unsigned int result;
+};
+
+struct pt_regs {
+	union {
+		struct user_pt_regs user_regs;
+		struct {
+			long unsigned int gpr[32];
+			long unsigned int nip;
+			long unsigned int msr;
+			long unsigned int orig_gpr3;
+			long unsigned int ctr;
+			long unsigned int link;
+			long unsigned int xer;
+			long unsigned int ccr;
+			long unsigned int softe;
+			long unsigned int trap;
+			long unsigned int dar;
+			long unsigned int dsisr;
+			long unsigned int result;
+		};
+	};
+	union {
+		struct {
+			long unsigned int ppr;
+			long unsigned int kuap;
+		};
+		long unsigned int __pad[2];
+	};
+};
+
+#endif /* __VMLINUX_ARCH_POWERPC_H__ */

--- a/headers/vmlinux/arch/x86/vmlinux.h
+++ b/headers/vmlinux/arch/x86/vmlinux.h
@@ -1,6 +1,12 @@
 #ifndef __VMLINUX_ARCH_X86_H__
 #define __VMLINUX_ARCH_X86_H__
 
+#ifdef __BPF_TRACING_H__
+/* Expected include <bpf/bpf_tracing.h> */
+#ifndef bpf_target_defined
+#warning "Tracing need __TARGET_ARCH_x86 defined"
+#endif
+#endif /*  __BPF_TRACING_H__ */
 
 struct pt_regs {
 	long unsigned int r15;

--- a/headers/vmlinux/arch/x86/vmlinux.h
+++ b/headers/vmlinux/arch/x86/vmlinux.h
@@ -1,0 +1,29 @@
+#ifndef __VMLINUX_ARCH_X86_H__
+#define __VMLINUX_ARCH_X86_H__
+
+
+struct pt_regs {
+	long unsigned int r15;
+	long unsigned int r14;
+	long unsigned int r13;
+	long unsigned int r12;
+	long unsigned int bp;
+	long unsigned int bx;
+	long unsigned int r11;
+	long unsigned int r10;
+	long unsigned int r9;
+	long unsigned int r8;
+	long unsigned int ax;
+	long unsigned int cx;
+	long unsigned int dx;
+	long unsigned int si;
+	long unsigned int di;
+	long unsigned int orig_ax;
+	long unsigned int ip;
+	long unsigned int cs;
+	long unsigned int flags;
+	long unsigned int sp;
+	long unsigned int ss;
+};
+
+#endif /* __VMLINUX_ARCH_X86_H__ */

--- a/headers/vmlinux/vmlinux_common.h
+++ b/headers/vmlinux/vmlinux_common.h
@@ -1,0 +1,26 @@
+#ifndef __VMLINUX_COMMON_H__
+#define __VMLINUX_COMMON_H__
+
+struct list_head {
+	struct list_head *next;
+	struct list_head *prev;
+};
+
+struct rb_node {
+	long unsigned int __rb_parent_color;
+	struct rb_node *rb_right;
+	struct rb_node *rb_left;
+};
+
+typedef struct {
+	int counter;
+} atomic_t;
+
+struct refcount_struct {
+	atomic_t refs;
+};
+
+typedef struct refcount_struct refcount_t;
+
+
+#endif /* __VMLINUX_COMMON_H__ */

--- a/headers/vmlinux/vmlinux_net.h
+++ b/headers/vmlinux/vmlinux_net.h
@@ -1,0 +1,138 @@
+#ifndef __VMLINUX_NET_H__
+#define __VMLINUX_NET_H__
+
+typedef __u32 __wsum;
+
+typedef unsigned int sk_buff_data_t; // Assumes 64-bit. FIXME see below
+/*
+// BITS_PER_LONG can be wrong with -target bpf
+#if BITS_PER_LONG > 32
+#define NET_SKBUFF_DATA_USES_OFFSET 1
+#endif
+
+#ifdef NET_SKBUFF_DATA_USES_OFFSET
+typedef unsigned int sk_buff_data_t;
+#else
+typedef unsigned char *sk_buff_data_t;
+#endif
+*/
+
+struct sk_buff {
+	union {
+		struct {
+			struct sk_buff *next;
+			struct sk_buff *prev;
+			union {
+				struct net_device *dev;
+				long unsigned int dev_scratch;
+			};
+		};
+		struct rb_node rbnode;
+		struct list_head list;
+	};
+	union {
+		struct sock *sk;
+		int ip_defrag_offset;
+	};
+	union {
+		ktime_t tstamp;
+		u64 skb_mstamp_ns;
+	};
+	char cb[48];
+	union {
+		struct {
+			long unsigned int _skb_refdst;
+			void (*destructor)(struct sk_buff *);
+		};
+		struct list_head tcp_tsorted_anchor;
+	};
+	long unsigned int _nfct;
+	unsigned int len;
+	unsigned int data_len;
+	__u16 mac_len;
+	__u16 hdr_len;
+	__u16 queue_mapping;
+	__u8 __cloned_offset[0];
+	__u8 cloned: 1;
+	__u8 nohdr: 1;
+	__u8 fclone: 2;
+	__u8 peeked: 1;
+	__u8 head_frag: 1;
+	__u8 pfmemalloc: 1;
+	__u8 active_extensions;
+	__u32 headers_start[0];
+	__u8 __pkt_type_offset[0];
+	__u8 pkt_type: 3;
+	__u8 ignore_df: 1;
+	__u8 nf_trace: 1;
+	__u8 ip_summed: 2;
+	__u8 ooo_okay: 1;
+	__u8 l4_hash: 1;
+	__u8 sw_hash: 1;
+	__u8 wifi_acked_valid: 1;
+	__u8 wifi_acked: 1;
+	__u8 no_fcs: 1;
+	__u8 encapsulation: 1;
+	__u8 encap_hdr_csum: 1;
+	__u8 csum_valid: 1;
+	__u8 __pkt_vlan_present_offset[0];
+	__u8 vlan_present: 1;
+	__u8 csum_complete_sw: 1;
+	__u8 csum_level: 2;
+	__u8 csum_not_inet: 1;
+	__u8 dst_pending_confirm: 1;
+	__u8 ndisc_nodetype: 2;
+	__u8 ipvs_property: 1;
+	__u8 inner_protocol_type: 1;
+	__u8 remcsum_offload: 1;
+	__u8 offload_fwd_mark: 1;
+	__u8 offload_l3_fwd_mark: 1;
+	__u8 tc_skip_classify: 1;
+	__u8 tc_at_ingress: 1;
+	__u8 redirected: 1;
+	__u8 from_ingress: 1;
+	__u8 decrypted: 1;
+	__u16 tc_index;
+	union {
+		__wsum csum;
+		struct {
+			__u16 csum_start;
+			__u16 csum_offset;
+		};
+	};
+	__u32 priority;
+	int skb_iif;
+	__u32 hash;
+	__be16 vlan_proto;
+	__u16 vlan_tci;
+	union {
+		unsigned int napi_id;
+		unsigned int sender_cpu;
+	};
+	__u32 secmark;
+	union {
+		__u32 mark;
+		__u32 reserved_tailroom;
+	};
+	union {
+		__be16 inner_protocol;
+		__u8 inner_ipproto;
+	};
+	__u16 inner_transport_header;
+	__u16 inner_network_header;
+	__u16 inner_mac_header;
+	__be16 protocol;
+	__u16 transport_header;
+	__u16 network_header;
+	__u16 mac_header;
+	__u32 headers_end[0];
+	sk_buff_data_t tail;
+	sk_buff_data_t end;
+	unsigned char *head;
+	unsigned char *data;
+	unsigned int truesize;
+	refcount_t users;
+	struct skb_ext *extensions;
+};
+
+#endif /* __VMLINUX_NET_H__ */

--- a/headers/vmlinux/vmlinux_types.h
+++ b/headers/vmlinux/vmlinux_types.h
@@ -1,0 +1,14 @@
+#ifndef __VMLINUX_TYPES_H__
+#define __VMLINUX_TYPES_H__
+
+typedef __u8 u8;
+typedef __s16 s16;
+typedef __u16 u16;
+typedef __s32 s32;
+typedef __u32 u32;
+typedef __s64 s64;
+typedef __u64 u64;
+
+typedef s64 ktime_t;
+
+#endif /* __VMLINUX_TYPES_H__ */

--- a/headers/vmlinux_local.h
+++ b/headers/vmlinux_local.h
@@ -9,10 +9,6 @@
  */
 #ifndef __VMLINUX_H__
 #define __VMLINUX_H__
-/*
- * Notice: Defining __VMLINUX_H__ (or __KERNEL__) cause <bpf/bpf_tracing.h>
- *         header file to define architecture specific PT_REGS_PARM's.
- */
 
 #include <linux/types.h> /* Needed for __uNN in vmlinux/vmlinux_types.h */
 
@@ -23,6 +19,22 @@
 #include "vmlinux/vmlinux_types.h"
 #include "vmlinux/vmlinux_common.h"
 #include "vmlinux/vmlinux_net.h"
+
+/*
+ * Notice: Defining __VMLINUX_H__ (or __KERNEL__) cause <bpf/bpf_tracing.h>
+ *         header file to define architecture specific PT_REGS_PARM's.
+ *
+ * When using '-target bpf' the fallback mechanism doesn't detect right arch
+ * via  compiler defines.
+ *
+ * Makefile system in lib/common.mk detect ARCH and defines the
+ * defines __TARGET_ARCH_$(ARCH) matched on below.
+ */
+#if defined(__TARGET_ARCH_x86)
+#include "vmlinux/arch/x86/vmlinux.h"
+#else
+#warning "Makefile for BPF-tracing on this arch: not supported yet"
+#endif
 
 #ifndef BPF_NO_PRESERVE_ACCESS_INDEX
 #pragma clang attribute pop

--- a/headers/vmlinux_local.h
+++ b/headers/vmlinux_local.h
@@ -18,23 +18,11 @@
 
 #include "vmlinux/vmlinux_types.h"
 #include "vmlinux/vmlinux_common.h"
+
+#include "vmlinux/vmlinux_arch.h"
+
 #include "vmlinux/vmlinux_net.h"
 
-/*
- * Notice: Defining __VMLINUX_H__ (or __KERNEL__) cause <bpf/bpf_tracing.h>
- *         header file to define architecture specific PT_REGS_PARM's.
- *
- * When using '-target bpf' the fallback mechanism doesn't detect right arch
- * via  compiler defines.
- *
- * Makefile system in lib/common.mk detect ARCH and defines the
- * defines __TARGET_ARCH_$(ARCH) matched on below.
- */
-#if defined(__TARGET_ARCH_x86)
-#include "vmlinux/arch/x86/vmlinux.h"
-#else
-#warning "Makefile for BPF-tracing on this arch: not supported yet"
-#endif
 
 #ifndef BPF_NO_PRESERVE_ACCESS_INDEX
 #pragma clang attribute pop

--- a/headers/vmlinux_local.h
+++ b/headers/vmlinux_local.h
@@ -18,11 +18,8 @@
 
 #include "vmlinux/vmlinux_types.h"
 #include "vmlinux/vmlinux_common.h"
-
 #include "vmlinux/vmlinux_arch.h"
-
 #include "vmlinux/vmlinux_net.h"
-
 
 #ifndef BPF_NO_PRESERVE_ACCESS_INDEX
 #pragma clang attribute pop

--- a/headers/vmlinux_local.h
+++ b/headers/vmlinux_local.h
@@ -1,0 +1,31 @@
+/*
+ * WARNING: This file shadow vmlinux.h that you can generate yourself
+ *
+ * Cmdline to generate vmlinux.h
+ *  bpftool btf dump file /sys/kernel/btf/vmlinux format c > vmlinux.h
+ *
+ * This vmlinux.h shadow contains kernel headers reduced to that were
+ * needed in this project.
+ */
+#ifndef __VMLINUX_H__
+#define __VMLINUX_H__
+/*
+ * Notice: Defining __VMLINUX_H__ (or __KERNEL__) cause <bpf/bpf_tracing.h>
+ *         header file to define architecture specific PT_REGS_PARM's.
+ */
+
+#include <linux/types.h> /* Needed for __uNN in vmlinux/vmlinux_types.h */
+
+#ifndef BPF_NO_PRESERVE_ACCESS_INDEX
+#pragma clang attribute push (__attribute__((preserve_access_index)), apply_to = record)
+#endif
+
+#include "vmlinux/vmlinux_types.h"
+#include "vmlinux/vmlinux_common.h"
+#include "vmlinux/vmlinux_net.h"
+
+#ifndef BPF_NO_PRESERVE_ACCESS_INDEX
+#pragma clang attribute pop
+#endif
+
+#endif /* __VMLINUX_H__ */

--- a/ktrace-CO-RE/Makefile
+++ b/ktrace-CO-RE/Makefile
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0
+
+# The BPF tracing header (/usr/include/bpf/bpf_tracing.h) need to know
+# CPU architecture due to PT_REGS_PARM resolution of ASM call convention
+ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/')
+
+USER_TARGETS := ktrace01
+BPF_TARGETS  := ktrace01_kern
+
+LIB_DIR = ../lib
+
+include $(LIB_DIR)/common.mk
+
+BPF_CFLAGS += -D__TARGET_ARCH_$(ARCH)

--- a/ktrace-CO-RE/Makefile
+++ b/ktrace-CO-RE/Makefile
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
 
-# The BPF tracing header (/usr/include/bpf/bpf_tracing.h) need to know
-# CPU architecture due to PT_REGS_PARM resolution of ASM call convention
-ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/')
-
 USER_TARGETS := ktrace01
 BPF_TARGETS  := ktrace01_kern
 

--- a/ktrace-CO-RE/Makefile
+++ b/ktrace-CO-RE/Makefile
@@ -7,4 +7,5 @@ LIB_DIR = ../lib
 
 include $(LIB_DIR)/common.mk
 
-BPF_CFLAGS += -D__TARGET_ARCH_$(ARCH)
+# The __TARGET_ARCH_xxx is defined in lib/common.mk
+# BPF_CFLAGS += -D__TARGET_ARCH_$(ARCH)

--- a/ktrace-CO-RE/README.org
+++ b/ktrace-CO-RE/README.org
@@ -3,5 +3,45 @@
 This is an example that show how CO-RE came be utilised...
 to learn CO-RE and BTF better.
 
+* Compiling kprobes for different CPU architectures
 
+When BPF-tracing =kprobes= then the header files need to use the correct
+asm-level C-calling convention for the architecture that this is getting
+compiled for, as BPF will be hook/tap directly into the kernels function
+call. These are the raw CPU registers, which we later via BTF demonstrate
+howto use to CO-RE to get the C-type back.
 
+The header include file =<bpf/bpf_tracing.h>= takes care of defining macros
+for accessing the members in kernels =struct pt_regs=, as the struct member
+names differ between architectures. This header file is provided by [[https://github.com/libbpf/libbpf][libbpf]]
+(or distros libbpf-devel package).
+
+The architecture specific definition of =struct pt_regs= can be extracted
+via generating a vmlinux.h file on the ARCH target. To ease getting the
+structs this git repo contains the arch include files here:
+[[file:../headers/vmlinux/arch/]]
+
+You should not include them directly, but instead include [[file:../headers/vmlinux_local.h][vmlinux_local.h]] to
+get the surrounding types defined.
+
+** Gotcha with target bpf
+
+This git-repo compile with clang =-target bpf=. This cause issues for
+=ktrace=, because the fallback mechanism in header file
+=<bpf/bpf_tracing.h>= cannot determine the ARCH from compiler defines.
+
+To solve this our makefile system in [[file:../lib/common.mk]] detect the ARCH
+(via =uname -m=) and defines the =__TARGET_ARCH_$(ARCH)= in =BPF_CFLAGS=.
+
+Without this fix the following compile warnings occurs:
+#+begin_example
+ warning: implicit declaration of function 'PT_REGS_PARM1' is invalid in C99
+ int BPF_KPROBE(udp_send_skb, struct sk_buff *skb)
+     ^
+ /usr/include/bpf/bpf_tracing.h:385:20: note: expanded from macro 'BPF_KPROBE'
+#+end_example
+
+When loading via libbpf the following error happens:
+#+begin_example
+ libbpf: failed to find BTF for extern 'PT_REGS_PARM1': -2
+#+end_example

--- a/ktrace-CO-RE/README.org
+++ b/ktrace-CO-RE/README.org
@@ -1,0 +1,7 @@
+#+Title: Example using CO-RE to access ktrace
+
+This is an example that show how CO-RE came be utilised...
+to learn CO-RE and BTF better.
+
+
+

--- a/ktrace-CO-RE/README.org
+++ b/ktrace-CO-RE/README.org
@@ -45,3 +45,26 @@ When loading via libbpf the following error happens:
 #+begin_example
  libbpf: failed to find BTF for extern 'PT_REGS_PARM1': -2
 #+end_example
+
+* Bpftrace
+
+Pre-investigations with bpftrace.
+
+Simple =bpftrace= command to look at callstack for =udp_send_skb=:
+ - bpftrace -e 'kprobe:udp_send_skb { @[kstack] = count() }'
+
+#+begin_src sh
+$ sudo bpftrace -e 'kprobe:udp_send_skb { @[kstack] = count() }'
+Attaching 1 probe...
+^C
+
+@[
+    udp_send_skb+1
+    udp_sendmsg+2407
+    sock_sendmsg+87
+    __sys_sendto+238
+    __x64_sys_sendto+37
+    do_syscall_64+51
+    entry_SYSCALL_64_after_hwframe+68
+]: 70
+#+end_src

--- a/ktrace-CO-RE/ktrace01.c
+++ b/ktrace-CO-RE/ktrace01.c
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0+
+// static const char *__doc__ = " Trivial ktrace example";
+
+#include <bpf/libbpf.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include <stdio.h>
+
+#define pr_err(fmt, ...) \
+	fprintf(stderr, "%s:%d - " fmt, __FILE__, __LINE__, ##__VA_ARGS__)
+
+int main(int argc, char **argv)
+{
+	struct bpf_object *obj = NULL;
+	struct bpf_link *link = NULL;
+	struct bpf_program *prog;
+	char filename[256];
+	//char pin_file[256];
+	// char *pin_file;
+	char buf[100];
+	int err;
+	int c;
+
+	snprintf(filename, sizeof(filename), "%s_kern.o", argv[0]);
+
+        obj = bpf_object__open_file(filename, NULL);
+	err = libbpf_get_error(obj);
+	if (err) {
+		libbpf_strerror(err, buf, sizeof(buf));
+		pr_err("Error(%d) opening file: %s\n", err, buf);
+		goto out;
+	}
+
+	err = bpf_object__load(obj);
+	if (err) {
+		libbpf_strerror(err, buf, sizeof(buf));
+		pr_err("Error(%d) loading: %s\n", err, buf);
+		goto out;
+	}
+
+	prog = bpf_program__next(NULL, obj);
+	if (!prog) {
+		pr_err("No program!\n");
+		err = -ENOENT;
+		goto out;
+	}
+
+	link = bpf_program__attach(prog);
+	err = libbpf_get_error(link);
+	if (err) {
+		libbpf_strerror(err, buf, sizeof(buf));
+		pr_err("Error(%d) attaching: %s\n", err, buf);
+		goto out;
+	}
+
+	printf("Loaded BPF file %s\n", filename);
+	printf( "Press any key + enter to unload program again [Y/y]:");
+	c = getchar();
+	putchar(c);
+
+	// snprintf(pin_file, sizeof(pin_file), "/sys/fs/bpf/%s", argv[0]);
+	/*
+	pin_file = "/sys/fs/bpf/ktrace01";
+	err = bpf_link__pin(link, pin_file);
+	printf("pin_file %s\n", pin_file);
+	if (err) {
+		libbpf_strerror(err, buf, sizeof(buf));
+		pr_err("Error(%d) pinning: %s\n", err, buf);
+		goto out;
+	}
+	printf("Loaded BPF file %s (pinned at %s)\n", filename, pin_file);
+	*/
+out:
+	bpf_link__destroy(link);
+	bpf_object__close(obj);
+	if (err)
+		return EXIT_FAILURE;
+	return EXIT_SUCCESS;
+}

--- a/ktrace-CO-RE/ktrace01.c
+++ b/ktrace-CO-RE/ktrace01.c
@@ -72,6 +72,7 @@ int main(int argc, char **argv)
 		err = -ENOENT;
 		goto out;
 	}
+	printf("Loaded BPF file %s\n", filename);
 
 	link = bpf_program__attach(prog);
 	err = libbpf_get_error(link);
@@ -81,25 +82,10 @@ int main(int argc, char **argv)
 		goto out;
 	}
 
-	printf("Loaded BPF file %s\n", filename);
-	printf( "Press any key + enter to unload program again [Y/y]:");
-	//c = getchar();
-	//putchar(c);
-
+	printf("Attached and reading trace_pipe\n");
+	printf(" - Press Ctrl-C to unload program again\n");
 	read_trace_pipe();
 
-	// snprintf(pin_file, sizeof(pin_file), "/sys/fs/bpf/%s", argv[0]);
-	/*
-	pin_file = "/sys/fs/bpf/ktrace01";
-	err = bpf_link__pin(link, pin_file);
-	printf("pin_file %s\n", pin_file);
-	if (err) {
-		libbpf_strerror(err, buf, sizeof(buf));
-		pr_err("Error(%d) pinning: %s\n", err, buf);
-		goto out;
-	}
-	printf("Loaded BPF file %s (pinned at %s)\n", filename, pin_file);
-	*/
 out:
 	bpf_link__destroy(link);
 	bpf_object__close(obj);

--- a/ktrace-CO-RE/ktrace01_kern.c
+++ b/ktrace-CO-RE/ktrace01_kern.c
@@ -31,8 +31,22 @@ struct trace_event_raw_bpf_trace_printk___x {};
  })
 /* Gotcha: bpf_core_type_exists() needs __builtin_preserve_type_info */
 
+/* Example of using triple-underscore and preserve_access_index
+ * --------------------------------------------------------------------------
+ * This demonstrates how it is possible define a local struct that shadow the
+ * real kernel struct sk_buff. But only defining the members that the program
+ * are interested in. The CO-RE infra-structure will remap the member offsets to
+ * the correct offsets used by the kernel. This require adding the LLVM
+ * attribute "preserve_access_index". Notice the triple-underscore after the
+ * real struct name, which libbpf match and adjust prior to BPF-loading.
+ */
+struct sk_buff___local {
+	unsigned int len;
+	__u32 hash;
+} __attribute__((preserve_access_index));
+
 SEC("kprobe/udp_send_skb")
-int BPF_KPROBE(udp_send_skb, struct sk_buff *skb)
+int BPF_KPROBE(udp_send_skb, struct sk_buff___local *skb)
 //int udp_send_skb(struct pt_regs *ctx)
 {
 	unsigned int len;

--- a/ktrace-CO-RE/ktrace01_kern.c
+++ b/ktrace-CO-RE/ktrace01_kern.c
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+char _license[] SEC("license") = "GPL";
+
+struct my_struct {
+	int v;
+	__u64 m2;
+};
+
+SEC("kprobe/open_ctree")
+int bpf_prog1(struct pt_regs *ctx)
+{
+	unsigned long rc = 0;
+	struct my_struct a;
+
+        //a.v = 42;
+
+	// bpf_override_return(ctx, rc);
+        if (a.v == 43)
+                return 0;
+	return a.v;
+}

--- a/ktrace-CO-RE/ktrace01_kern.c
+++ b/ktrace-CO-RE/ktrace01_kern.c
@@ -1,14 +1,15 @@
 /* SPDX-License-Identifier: GPL-2.0+ */
 //#include "vmlinux.h"
 
-#include "kernel_headers.h"
+//#include "kernel_headers.h"
+#include "vmlinux_local.h"
 
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
 
 #include <bpf/bpf_core_read.h>
 
--/* Fall back to what the compiler says */
+/* Fall back to what the compiler says */
 #ifndef bpf_target_defined
 #if defined(__x86_64__)
        #define bpf_target_x86

--- a/ktrace-CO-RE/ktrace01_kern.c
+++ b/ktrace-CO-RE/ktrace01_kern.c
@@ -1,14 +1,11 @@
 /* SPDX-License-Identifier: GPL-2.0+ */
-//#include "vmlinux.h"
 
-//#include "kernel_headers.h"
 #include "vmlinux_local.h"
 
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
 
-#include <bpf/bpf_core_read.h>
-
+#include <bpf/bpf_core_read.h> /* CO-RE */
 #include <bpf/bpf_tracing.h> /* BPF_KPROBE */
 
 #ifndef bpf_target_defined
@@ -26,29 +23,18 @@ struct my_struct G = {};
 
 SEC("kprobe/udp_send_skb")
 int BPF_KPROBE(udp_send_skb, struct sk_buff *skb)
-// int bpf_prog1(struct pt_regs *ctx, struct sk_buff *skb)
-//int bpf_prog1(struct sk_buff *ctx)
+//int udp_send_skb(struct pt_regs *ctx)
 {
-	// unsigned long rc = 0;
 	struct my_struct a;
-        int x = 42; //skb->hash;
+	int x = 42; //skb->hash;
 
-        BPF_CORE_READ_INTO(&x, skb, hash);
+	BPF_CORE_READ_INTO(&x, skb, hash);
 
 	G.v = 42;
 
 	a.v = bpf_get_prandom_u32() * x;
 
-	// bpf_override_return(ctx, rc);
 	if (a.v == 43)
 		return 0;
 	return G.v;
 }
-
-/*
-SEC("kprobe/tcp_v6_connect")
-int BPF_KPROBE(tcp_v6_connect, struct sock *sk)
-{
-	return trace_connect(sk);
-}
-*/

--- a/ktrace-CO-RE/ktrace01_kern.c
+++ b/ktrace-CO-RE/ktrace01_kern.c
@@ -31,29 +31,15 @@ struct trace_event_raw_bpf_trace_printk___x {};
  })
 /* Gotcha: bpf_core_type_exists() needs __builtin_preserve_type_info */
 
-struct my_struct {
-	int v;
-	__u64 m2;
-};
-
-struct my_struct G = {};
-
 SEC("kprobe/udp_send_skb")
 int BPF_KPROBE(udp_send_skb, struct sk_buff *skb)
 //int udp_send_skb(struct pt_regs *ctx)
 {
-	struct my_struct a;
-	int x = 42; //skb->hash;
+	__u32 h;
 
-	BPF_CORE_READ_INTO(&x, skb, hash);
+	BPF_CORE_READ_INTO(&h, skb, hash); /* skb->hash */
 
-	G.v = 42;
+	bpf_printk("skb->hash = 0x%x ", h);
 
-	a.v = bpf_get_prandom_u32() * x;
-
-	bpf_printk("skb->hash = 0x%x", x);
-
-	if (a.v == 43)
-		return 0;
-	return G.v;
+	return 0;
 }

--- a/ktrace-CO-RE/ktrace01_kern.c
+++ b/ktrace-CO-RE/ktrace01_kern.c
@@ -1,6 +1,46 @@
 /* SPDX-License-Identifier: GPL-2.0+ */
+//#include "vmlinux.h"
+
+#include "kernel_headers.h"
+
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
+
+#include <bpf/bpf_core_read.h>
+
+-/* Fall back to what the compiler says */
+#ifndef bpf_target_defined
+#if defined(__x86_64__)
+       #define bpf_target_x86
+#elif defined(__s390__)
+       #define bpf_target_s390
+#elif defined(__arm__)
+       #define bpf_target_arm
+-#elif defined(__aarch64__)
+       #define bpf_target_arm64
+#elif defined(__mips__)
+       #define bpf_target_mips
+#elif defined(__powerpc__)
+       #define bpf_target_powerpc
+#elif defined(__sparc__)
+       #define bpf_target_sparc
+#endif
+#endif
+
+#if !defined(bpf_target_x86)
+#warning "no--bpf_target_x86"
+#endif
+
+/* */
+//#ifndef __KERNEL__
+//#define __KERNEL__
+//#endif
+// #define __VMLINUX_H__
+#include <bpf/bpf_tracing.h> /* BPF_KPROBE */
+
+#ifndef bpf_target_defined
+#warning "Tracing need __TARGET_ARCH_xxx defines"
+#endif
 
 char _license[] SEC("license") = "GPL";
 
@@ -9,16 +49,33 @@ struct my_struct {
 	__u64 m2;
 };
 
-SEC("kprobe/open_ctree")
-int bpf_prog1(struct pt_regs *ctx)
-{
-	unsigned long rc = 0;
-	struct my_struct a;
+struct my_struct G = {};
 
-        //a.v = 42;
+SEC("kprobe/udp_send_skb")
+int BPF_KPROBE(udp_send_skb, struct sk_buff *skb)
+// int bpf_prog1(struct pt_regs *ctx, struct sk_buff *skb)
+//int bpf_prog1(struct sk_buff *ctx)
+{
+	// unsigned long rc = 0;
+	struct my_struct a;
+        int x = 42; //skb->hash;
+
+        BPF_CORE_READ_INTO(&x, skb, hash);
+
+	G.v = 42;
+
+	a.v = bpf_get_prandom_u32() * x;
 
 	// bpf_override_return(ctx, rc);
-        if (a.v == 43)
-                return 0;
-	return a.v;
+	if (a.v == 43)
+		return 0;
+	return G.v;
 }
+
+/*
+SEC("kprobe/tcp_v6_connect")
+int BPF_KPROBE(tcp_v6_connect, struct sock *sk)
+{
+	return trace_connect(sk);
+}
+*/

--- a/ktrace-CO-RE/ktrace01_kern.c
+++ b/ktrace-CO-RE/ktrace01_kern.c
@@ -50,12 +50,16 @@ int BPF_KPROBE(udp_send_skb, struct sk_buff___local *skb)
 //int udp_send_skb(struct pt_regs *ctx)
 {
 	unsigned int len;
+	__u32 id;
 	__u32 h;
+
+	/* Find the kernels BTF_ID for struct sk_buff */
+	id = bpf_core_type_id_kernel(struct sk_buff___local);
 
 	BPF_CORE_READ_INTO(&h,    skb, hash);		/* skb->hash */
 	BPF_CORE_READ_INTO(&len,  skb, len);		/* skb->len */
 
-	bpf_printk("skb->hash=0x%x len=%d", h, len);
+	bpf_printk("skb->hash=0x%x len=%d btf_id(skb)=%d", h, len, id);
 
 	return 0;
 }

--- a/ktrace-CO-RE/ktrace01_kern.c
+++ b/ktrace-CO-RE/ktrace01_kern.c
@@ -35,11 +35,13 @@ SEC("kprobe/udp_send_skb")
 int BPF_KPROBE(udp_send_skb, struct sk_buff *skb)
 //int udp_send_skb(struct pt_regs *ctx)
 {
+	unsigned int len;
 	__u32 h;
 
-	BPF_CORE_READ_INTO(&h, skb, hash); /* skb->hash */
+	BPF_CORE_READ_INTO(&h,    skb, hash);		/* skb->hash */
+	BPF_CORE_READ_INTO(&len,  skb, len);		/* skb->len */
 
-	bpf_printk("skb->hash = 0x%x ", h);
+	bpf_printk("skb->hash=0x%x len=%d", h, len);
 
 	return 0;
 }

--- a/ktrace-CO-RE/ktrace01_kern.c
+++ b/ktrace-CO-RE/ktrace01_kern.c
@@ -9,34 +9,6 @@
 
 #include <bpf/bpf_core_read.h>
 
-/* Fall back to what the compiler says */
-#ifndef bpf_target_defined
-#if defined(__x86_64__)
-       #define bpf_target_x86
-#elif defined(__s390__)
-       #define bpf_target_s390
-#elif defined(__arm__)
-       #define bpf_target_arm
--#elif defined(__aarch64__)
-       #define bpf_target_arm64
-#elif defined(__mips__)
-       #define bpf_target_mips
-#elif defined(__powerpc__)
-       #define bpf_target_powerpc
-#elif defined(__sparc__)
-       #define bpf_target_sparc
-#endif
-#endif
-
-#if !defined(bpf_target_x86)
-#warning "no--bpf_target_x86"
-#endif
-
-/* */
-//#ifndef __KERNEL__
-//#define __KERNEL__
-//#endif
-// #define __VMLINUX_H__
 #include <bpf/bpf_tracing.h> /* BPF_KPROBE */
 
 #ifndef bpf_target_defined

--- a/lib/common.mk
+++ b/lib/common.mk
@@ -33,6 +33,13 @@ ifeq ($(SYSTEM_LIBBPF),n)
 	LIBBPF_SOURCES := $(wildcard $(LIBBPF_DIR)/src/*.[ch])
 endif
 
+# The BPF tracing header (/usr/include/bpf/bpf_tracing.h) need to know
+# CPU architecture due to PT_REGS_PARM resolution of ASM call convention
+#
+ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/')
+
+BPF_CFLAGS += -D__TARGET_ARCH_$(ARCH)
+
 # BPF-prog kern and userspace shares struct via header file:
 KERN_USER_H ?= $(wildcard common_kern_user.h)
 


### PR DESCRIPTION
"Learning by doing":
 - Learning what CO-RE can do via writing a simple kprobe tracing program use some of these features.

I had to change the Makefile system to handle `SEC("kprobe")` and macro `BPF_KPROBE` as compiling with `-target bpf` result in `PT_REGS_PARM1` not being defined. As `include <bpf/bpf_tracing.h>` cannot determine the ARCH from compiler defines.
To solve this detect the `ARCH` our makefile system in [file lib/common.mk](../lib/common.mk) (via `uname -m`) and defines the `__TARGET_ARCH_$(ARCH)` in `BPF_CFLAGS`.

This PR also contains some `vmlinux.h` header variants for a number of ARCHs.
Choose to splitup `vmlinux_*.h` headers and only include what was needed for this example.
We will see how much maintenance this cause, and if this is the case we can consider adding the full `vmlinux.h` later.
