### PR TITLE
Embedding libxdp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = lib/libbpf
 	url = https://github.com/xdp-project/libbpf.git
 	ignore = dirty
+[submodule "lib/xdp-tools"]
+	path = lib/xdp-tools
+	url = https://github.com/xdp-project/xdp-tools

--- a/configure
+++ b/configure
@@ -127,11 +127,8 @@ EOF
     echo submodule
     SUBMODULE_LIBBPF=1
     echo "SYSTEM_LIBBPF:=n" >> $CONFIG
-    echo 'CFLAGS += -I$(LIB_DIR)/lib-install/usr/include' >>$CONFIG
-    echo 'BPF_CFLAGS += -I$(LIB_DIR)/lib-install/usr/include' >>$CONFIG
-    echo 'LDFLAGS += -L$(LIB_DIR)/libbpf/src' >>$CONFIG
     echo 'LDLIBS += -l:libbpf.a' >>$CONFIG
-    echo 'OBJECT_LIBBPF = $(LIB_DIR)/libbpf/src/libbpf.a' >>$CONFIG
+    echo 'OBJECT_LIBBPF = $(LIB_DIR)/install/lib/libbpf.a' >>$CONFIG
     if ! [ -d "lib/libbpf/src" ] && [ -f ".gitmodules" ] && [ -e ".git" ]; then
         git submodule init && git submodule update
     fi
@@ -195,18 +192,15 @@ check_libxdp()
     echo "SYSTEM_LIBXDP:=n" >> $CONFIG
     if [ "$SUBMODULE_LIBBPF" -eq "1" ]; then
         echo "Configuring libxdp to use our libbpf submodule"
-        (export LIBBPF_DIR="$(readlink -m lib/libbpf)" LIBBPF_INCLUDE_DIR="$(readlink -m lib/lib-install/usr/include)";
+        (export LIBBPF_DIR="$(readlink -m lib/libbpf)" LIBBPF_INCLUDE_DIR="$(readlink -m lib/install/include)";
          cd lib/xdp-tools; ./configure)
     else
         echo "Configuring libxdp without our libbpf"
         (cd lib/xdp-tools; ./configure)
-        # these are already set if using libbpf as a submodule
-        echo 'CFLAGS += -I$(LIB_DIR)/lib-install/usr/include' >>$CONFIG
-        echo 'BPF_CFLAGS += -I$(LIB_DIR)/lib-install/usr/include' >>$CONFIG
     fi
-    echo 'LDFLAGS += -L$(LIB_DIR)/lib-install/usr/lib' >>$CONFIG
+    echo 'LDFLAGS += -L$(LIB_DIR)/install/lib' >>$CONFIG
     echo 'LDLIBS += -l:libxdp.a' >>$CONFIG
-    echo 'OBJECT_LIBXDP = $(LIB_DIR)/lib-install/usr/lib/libxdp.a' >>$CONFIG
+    echo 'OBJECT_LIBXDP = $(LIB_DIR)/install/lib/libxdp.a' >>$CONFIG
     if ! [ -d "lib/xdp-tools/lib" ] && [ -f ".gitmodules" ] && [ -e ".git" ]; then
         git submodule init && git submodule update
     fi

--- a/configure
+++ b/configure
@@ -11,6 +11,8 @@ CONFIG=".${CONFIG}.tmp"
 TMPDIR=$(mktemp -d config.XXXXXX)
 trap 'status=$?; rm -rf $TMPDIR; rm -f $CONFIG; exit $status' EXIT HUP INT QUIT TERM
 
+SUBMODULE_LIBBPF=0
+
 check_toolchain()
 {
     local clang_version
@@ -123,9 +125,10 @@ EOF
     fi
 
     echo submodule
+    SUBMODULE_LIBBPF=1
     echo "SYSTEM_LIBBPF:=n" >> $CONFIG
-    echo 'CFLAGS += -I$(LIB_DIR)/libbpf-install/usr/include' >>$CONFIG
-    echo 'BPF_CFLAGS += -I$(LIB_DIR)/libbpf-install/usr/include' >>$CONFIG
+    echo 'CFLAGS += -I$(LIB_DIR)/lib-install/usr/include' >>$CONFIG
+    echo 'BPF_CFLAGS += -I$(LIB_DIR)/lib-install/usr/include' >>$CONFIG
     echo 'LDFLAGS += -L$(LIB_DIR)/libbpf/src' >>$CONFIG
     echo 'LDLIBS += -l:libbpf.a' >>$CONFIG
     echo 'OBJECT_LIBBPF = $(LIB_DIR)/libbpf/src/libbpf.a' >>$CONFIG
@@ -173,6 +176,42 @@ EOF
     fi
 }
 
+check_libxdp()
+{
+    if [ "${FORCE_SUBMODULE_LIBXDP:-0}" -ne "1" ] && ${PKG_CONFIG} libxdp --exists; then
+
+        LIBXDP_CFLAGS=$(${PKG_CONFIG} libxdp --cflags)
+        LIBXDP_LDLIBS=$(${PKG_CONFIG} libxdp --libs)
+        echo "SYSTEM_LIBXDP:=y" >>$CONFIG
+        echo 'CFLAGS += ' $LIBXDP_CFLAGS >> $CONFIG
+        echo 'LDLIBS += ' $LIBXDP_LDLIBS >>$CONFIG
+        echo 'OBJECT_LIBXDP = ' >>$CONFIG
+        echo system
+
+        return 0
+    fi
+
+    echo submodule
+    echo "SYSTEM_LIBXDP:=n" >> $CONFIG
+    if [ "$SUBMODULE_LIBBPF" -eq "1" ]; then
+        echo "Configuring libxdp to use our libbpf submodule"
+        (export LIBBPF_DIR="$(readlink -m lib/libbpf)" LIBBPF_INCLUDE_DIR="$(readlink -m lib/lib-install/usr/include)";
+         cd lib/xdp-tools; ./configure)
+    else
+        echo "Configuring libxdp without our libbpf"
+        (cd lib/xdp-tools; ./configure)
+        # these are already set if using libbpf as a submodule
+        echo 'CFLAGS += -I$(LIB_DIR)/lib-install/usr/include' >>$CONFIG
+        echo 'BPF_CFLAGS += -I$(LIB_DIR)/lib-install/usr/include' >>$CONFIG
+    fi
+    echo 'LDFLAGS += -L$(LIB_DIR)/lib-install/usr/lib' >>$CONFIG
+    echo 'LDLIBS += -l:libxdp.a' >>$CONFIG
+    echo 'OBJECT_LIBXDP = $(LIB_DIR)/lib-install/usr/lib/libxdp.a' >>$CONFIG
+    if ! [ -d "lib/xdp-tools/lib" ] && [ -f ".gitmodules" ] && [ -e ".git" ]; then
+        git submodule init && git submodule update
+    fi
+}
+
 quiet_config()
 {
     cat <<EOF
@@ -211,6 +250,8 @@ check_toolchain
 
 echo -n "libbpf support: "
 check_libbpf
+echo -n "libxdp support: "
+check_libxdp
 
 check_bpf_use_errno
 

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,1 +1,0 @@
-lib-install

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,1 @@
+lib-install

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -60,7 +60,7 @@ P:= >/dev/null
 endif
 
 # Detect submodule libbpf source file changes
-LIBXDP_SOURCES := $(wildcard xdp-tools/lib/libxdp/*.[ch])
+LIBXDP_SOURCES := $(wildcard xdp-tools/lib/libxdp/libxdp*.[ch]) xdp-tools/lib/libxdp/xsk.c
 
 
 $(LIB_INSTALL)/lib/libxdp.a: $(LIBXDP_SOURCES)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -2,17 +2,18 @@
 LIBBPF_CFLAGS:=$(if $(CFLAGS),$(CFLAGS),-g -O2 -Werror -Wall) -fPIC
 
 LIB_DIR = .
+LIB_INSTALL := lib-install
 include defines.mk
 
 SUBDIRS=
 
-all: $(OBJECT_LIBBPF)
+all: $(OBJECT_LIBBPF) $(OBJECT_LIBXDP)
 	@set -e; \
 	for i in $(SUBDIRS); \
 	do echo; echo "  $$i"; $(MAKE) -C $$i; done
 
 .PHONY: clean
-clean: libbpf_clean
+clean: libbpf_clean libxdp_clean
 	@for i in $(SUBDIRS); \
 	do $(MAKE) -C $$i clean; done
 
@@ -21,7 +22,9 @@ install:
 	$(MAKE) -C libxdp install
 	$(MAKE) -C testing install
 
+
 libbpf: $(OBJECT_LIBBPF)
+libxdp: libbpf $(OBJECT_LIBXDP)
 
 # Handle libbpf as git submodule
 ifeq ($(SYSTEM_LIBBPF),n)
@@ -31,21 +34,45 @@ endif
 
 # Detect submodule libbpf source file changes
 LIBBPF_SOURCES := $(wildcard libbpf/src/*.[ch])
-LIBBPF_INSTALL := libbpf-install
-INSTDIR=../../$(LIBBPF_INSTALL)
 
-.PHONY: libbpf_clean
 libbpf/src/libbpf.a: $(LIBBPF_SOURCES)
 	@echo ; echo "  libbpf"
 	$(QUIET_CC)$(MAKE) -C libbpf/src CFLAGS="$(LIBBPF_CFLAGS)" $P
-	$(QUIET_INSTALL)$(MAKE) -C libbpf/src DESTDIR=$(INSTDIR) install_headers $P
+	$(QUIET_INSTALL)$(MAKE) -C libbpf/src DESTDIR=../../$(LIB_INSTALL) install_headers $P
 
+.PHONY: libbpf_clean
 libbpf_clean:
 	$(Q)$(MAKE) -C libbpf/src clean $P
-	$(Q)$(RM) -r $(LIBBPF_INSTALL)
+	$(Q)$(RM) -r $(LIB_INSTALL)
 
 else
 
 libbpf_clean:
+	@echo -n
+endif
+
+# Handle libbpf as git submodule
+ifeq ($(SYSTEM_LIBXDP),n)
+ifeq ($(VERBOSE),0)
+P:= >/dev/null
+endif
+
+# Detect submodule libbpf source file changes
+LIBXDP_SOURCES := $(wildcard xdp-tools/lib/libxdp/*.[ch])
+
+
+$(LIB_INSTALL)/usr/lib/libxdp.a: $(LIBXDP_SOURCES)
+	@echo ; echo "  libxdp"
+	$(QUIET_CC)$(MAKE) -C xdp-tools BUILD_STATIC_ONLY=1 libxdp  $P
+	$(QUIET_INSTALL)$(MAKE) -C xdp-tools DESTDIR=../../../$(LIB_INSTALL) PREFIX=/usr BUILD_STATIC_ONLY=1 libxdp_install $P
+
+.PHONY: libxdp_clean
+libxdp_clean:
+	$(Q)$(MAKE) -C xdp-tools clean $P
+	$(Q)$(RM) -r $(LIB_INSTALL)
+
+else
+
+libxdp_clean:
 	@echo -n
 endif

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -2,7 +2,7 @@
 LIBBPF_CFLAGS:=$(if $(CFLAGS),$(CFLAGS),-g -O2 -Werror -Wall) -fPIC
 
 LIB_DIR = .
-LIB_INSTALL := lib-install
+LIB_INSTALL := $(LIB_DIR)/install
 include defines.mk
 
 SUBDIRS=
@@ -16,6 +16,8 @@ all: $(OBJECT_LIBBPF) $(OBJECT_LIBXDP)
 clean: libbpf_clean libxdp_clean
 	@for i in $(SUBDIRS); \
 	do $(MAKE) -C $$i clean; done
+	$(Q)find $(LIB_INSTALL) -type f -not -name .gitignore -delete
+	$(Q)find $(LIB_INSTALL) -type d -empty -delete
 
 install:
 	install -m 0755 -d $(DESTDIR)$(HDRDIR)
@@ -35,15 +37,15 @@ endif
 # Detect submodule libbpf source file changes
 LIBBPF_SOURCES := $(wildcard libbpf/src/*.[ch])
 
-libbpf/src/libbpf.a: $(LIBBPF_SOURCES)
+$(LIB_INSTALL)/lib/libbpf.a: $(LIBBPF_SOURCES)
 	@echo ; echo "  libbpf"
 	$(QUIET_CC)$(MAKE) -C libbpf/src CFLAGS="$(LIBBPF_CFLAGS)" $P
-	$(QUIET_INSTALL)$(MAKE) -C libbpf/src DESTDIR=../../$(LIB_INSTALL) install_headers $P
+	$(QUIET_INSTALL)$(MAKE) -C libbpf/src DESTDIR=../../$(LIB_INSTALL) PREFIX= install_headers $P
+	$(Q)cp -fp libbpf/src/libbpf.a install/lib/
 
 .PHONY: libbpf_clean
 libbpf_clean:
 	$(Q)$(MAKE) -C libbpf/src clean $P
-	$(Q)$(RM) -r $(LIB_INSTALL)
 
 else
 
@@ -61,15 +63,14 @@ endif
 LIBXDP_SOURCES := $(wildcard xdp-tools/lib/libxdp/*.[ch])
 
 
-$(LIB_INSTALL)/usr/lib/libxdp.a: $(LIBXDP_SOURCES)
+$(LIB_INSTALL)/lib/libxdp.a: $(LIBXDP_SOURCES)
 	@echo ; echo "  libxdp"
 	$(QUIET_CC)$(MAKE) -C xdp-tools BUILD_STATIC_ONLY=1 libxdp  $P
-	$(QUIET_INSTALL)$(MAKE) -C xdp-tools DESTDIR=../../../$(LIB_INSTALL) PREFIX=/usr BUILD_STATIC_ONLY=1 libxdp_install $P
+	$(QUIET_INSTALL)$(MAKE) -C xdp-tools DESTDIR=../../../$(LIB_INSTALL) PREFIX= BUILD_STATIC_ONLY=1 libxdp_install $P
 
 .PHONY: libxdp_clean
 libxdp_clean:
 	$(Q)$(MAKE) -C xdp-tools clean $P
-	$(Q)$(RM) -r $(LIB_INSTALL)
 
 else
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -5,7 +5,7 @@ LIB_DIR = .
 LIB_INSTALL := $(LIB_DIR)/install
 include defines.mk
 
-SUBDIRS=
+SUBDIRS=util
 
 all: $(OBJECT_LIBBPF) $(OBJECT_LIBXDP)
 	@set -e; \

--- a/lib/common.mk
+++ b/lib/common.mk
@@ -47,8 +47,9 @@ BPF_CFLAGS += -D__TARGET_ARCH_$(ARCH)
 # BPF-prog kern and userspace shares struct via header file:
 KERN_USER_H ?= $(wildcard common_kern_user.h)
 
-CFLAGS += -I$(INCLUDE_DIR) -I$(HEADER_DIR) -I$(LIB_DIR)/util $(EXTRA_CFLAGS)
-BPF_CFLAGS += -I$(INCLUDE_DIR) -I$(HEADER_DIR) $(EXTRA_CFLAGS)
+CFLAGS += -I$(INCLUDE_DIR) -I$(HEADER_DIR) -I$(LIB_DIR)/util -I$(LIB_DIR)/install/include $(EXTRA_CFLAGS)
+BPF_CFLAGS += -I$(INCLUDE_DIR) -I$(HEADER_DIR) -I$(LIB_DIR)/install/include $(EXTRA_CFLAGS)
+LDFLAGS += -L$(LIB_DIR)/install/lib
 
 BPF_HEADERS := $(wildcard $(HEADER_DIR)/*/*.h) $(wildcard $(INCLUDE_DIR)/*/*.h)
 

--- a/lib/common.mk
+++ b/lib/common.mk
@@ -61,6 +61,9 @@ clean::
 $(OBJECT_LIBBPF): $(LIBBPF_SOURCES)
 	$(Q)$(MAKE) -C $(LIB_DIR) libbpf
 
+$(OBJECT_LIBXDP): $(LIBXDP_SOURCES)
+	$(Q)$(MAKE) -C $(LIB_DIR) libxdp
+
 $(CONFIGMK):
 	$(Q)$(MAKE) -C $(LIB_DIR)/.. config.mk
 

--- a/lib/install/.gitignore
+++ b/lib/install/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!include
+!lib

--- a/lib/install/include/.gitignore
+++ b/lib/install/include/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/lib/install/lib/.gitignore
+++ b/lib/install/lib/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/lib/util/Makefile
+++ b/lib/util/Makefile
@@ -1,0 +1,18 @@
+include util.mk
+
+LIB_DIR ?= ..
+
+include $(LIB_DIR)/defines.mk
+
+all: $(UTIL_OBJS)
+
+# Create expansions for dependencies
+UTIL_H := ${UTIL_OBJS:.o=.h}
+
+CFLAGS+= -I$(LIB_DIR)/install/include
+
+$(UTIL_OBJS): %.o: %.c $(UTIL_H) $(LIBMK)
+	$(QUIET_CC)$(CC) $(CFLAGS) -Wall -I../../headers -c -o $@ $<
+
+clean:
+	$(Q)rm -f $(UTIL_OBJS)

--- a/lib/util/logging.c
+++ b/lib/util/logging.c
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+#include <bpf/libbpf.h>
+#include <xdp/libxdp.h>
+
+#define __unused __attribute__((unused))
+#include "logging.h"
+
+static enum logging_print_level log_level = LOG_INFO;
+
+static int print_func(enum logging_print_level level, const char *format,
+		      va_list args)
+{
+	if (level > log_level)
+		return 0;
+
+	return vfprintf(stderr, format, args);
+}
+
+static int libbpf_print_func(enum libbpf_print_level level, const char *format,
+			     va_list args)
+{
+	return print_func(level + 1, format, args);
+}
+
+static int libbpf_silent_func(__unused enum libbpf_print_level level,
+			      __unused const char *format,
+			      __unused va_list args)
+{
+	return 0;
+}
+
+static int libxdp_print_func(enum libxdp_print_level level, const char *format,
+			     va_list args)
+{
+	return print_func(level + 1, format, args);
+}
+
+static int libxdp_silent_func(__unused enum libxdp_print_level level,
+			      __unused const char *format,
+			      __unused va_list args)
+{
+	return 0;
+}
+
+#define __printf(a, b) __attribute__((format(printf, a, b)))
+
+__printf(2, 3) void logging_print(enum logging_print_level level,
+				  const char *format, ...)
+{
+	va_list args;
+
+	va_start(args, format);
+	print_func(level, format, args);
+	va_end(args);
+}
+
+void init_lib_logging(void)
+{
+	libbpf_set_print(libbpf_print_func);
+	libxdp_set_print(libxdp_print_func);
+}
+
+void silence_libbpf_logging(void)
+{
+	if (log_level < LOG_VERBOSE)
+		libbpf_set_print(libbpf_silent_func);
+}
+
+void silence_libxdp_logging(void)
+{
+	if (log_level < LOG_VERBOSE)
+		libxdp_set_print(libxdp_silent_func);
+}
+
+enum logging_print_level set_log_level(enum logging_print_level level)
+{
+	enum logging_print_level old_level = log_level;
+
+	log_level = level;
+	return old_level;
+}
+
+enum logging_print_level increase_log_level(void)
+{
+	if (log_level < LOG_VERBOSE)
+		log_level++;
+	return log_level;
+}

--- a/lib/util/logging.h
+++ b/lib/util/logging.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef __LOGGING_H
+#define __LOGGING_H
+
+/* This matches the libbpf logging levels, but with an additional VERBOSE level;
+ * we demote all libbpf messages by one level so debug messages only show up on
+ * VERBOSE.
+ */
+enum logging_print_level {
+	LOG_WARN,
+	LOG_INFO,
+	LOG_DEBUG,
+	LOG_VERBOSE,
+};
+
+extern void logging_print(enum logging_print_level level, const char *format,
+			  ...) __attribute__((format(printf, 2, 3)));
+
+#define __pr(level, fmt, ...)                             \
+	do {                                              \
+		logging_print(level, fmt, ##__VA_ARGS__); \
+	} while (0)
+
+#define pr_warn(fmt, ...) __pr(LOG_WARN, fmt, ##__VA_ARGS__)
+#define pr_info(fmt, ...) __pr(LOG_INFO, fmt, ##__VA_ARGS__)
+#define pr_debug(fmt, ...) __pr(LOG_DEBUG, fmt, ##__VA_ARGS__)
+
+void init_lib_logging(void);
+void silence_libbpf_logging(void);
+void silence_libxdp_logging(void);
+enum logging_print_level set_log_level(enum logging_print_level level);
+enum logging_print_level increase_log_level();
+
+#endif

--- a/lib/util/util.mk
+++ b/lib/util/util.mk
@@ -1,2 +1,2 @@
 # list of objects in this directory
-UTIL_OBJS := json_writer.o
+UTIL_OBJS := json_writer.o logging.o

--- a/nat64-bpf/nat64.c
+++ b/nat64-bpf/nat64.c
@@ -20,6 +20,8 @@
 #include <libmnl/libmnl.h>
 #include <linux/rtnetlink.h>
 
+#include "logging.h"
+
 #include "nat64.h"
 #include "nat64_kern.skel.h"
 
@@ -34,6 +36,7 @@ static const struct option long_options[] = {
 	{ "v6-prefix",        required_argument, NULL, '6' }, // v6 prefix to use for nat64
 	{ "v4-prefix",        required_argument, NULL, '4' }, // v4 prefix to use for nat64
 	{ "timeout",          required_argument, NULL, 't' }, // Address mapping timeout interval in s
+	{ "verbose",          required_argument, NULL, 'v' }, // verbose logging
 	{ 0, 0, NULL, 0 }
 };
 
@@ -85,7 +88,7 @@ static int parse_arguments(int argc, char *argv[], struct nat64_user_config *con
 	config->c.v6_prefix.s6_addr[2] = 0xff;
 	config->c.v6_prefix.s6_addr[3] = 0x9b;
 
-	while ((opt = getopt_long(argc, argv, "i:6:4:t:a:hu", long_options,
+	while ((opt = getopt_long(argc, argv, "i:6:4:t:a:huv", long_options,
 				  NULL)) != -1) {
 		switch (opt) {
 		case 'i':
@@ -160,6 +163,9 @@ static int parse_arguments(int argc, char *argv[], struct nat64_user_config *con
 			break;
 		case 'u':
 			config->unload = true;
+			break;
+		case 'v':
+			increase_log_level();
 			break;
 		default:
 			fprintf(stderr, "Unknown option %s\n", argv[optind]);
@@ -361,6 +367,8 @@ int main(int argc, char *argv[])
 	DECLARE_LIBBPF_OPTS(bpf_tc_hook, hook, .attach_point = BPF_TC_INGRESS | BPF_TC_EGRESS);
 	DECLARE_LIBBPF_OPTS(bpf_tc_opts, attach_egress);
 	DECLARE_LIBBPF_OPTS(bpf_tc_opts, attach_ingress);
+
+	init_lib_logging();
 
 	err = parse_arguments(argc, argv, &cfg);
 	if (err)


### PR DESCRIPTION
This adds support for embedding libxdp and linking userspace binaries against it. It relies on recent changes in the xdp-tools repository to support this.

There's one outstanding issue with this: the embedded version of libxdp needs to be able to find the dispatcher BPF object, which it is not able to do with the custom install path currently. This needs to be fixed in upstream libxdp.