### PR TITLE
AF_XDP example added some results

### DIFF
--- a/AF_XDP-interaction/README.org
+++ b/AF_XDP-interaction/README.org
@@ -84,20 +84,20 @@ using the spin-mode, and effects of userspace running on same or a
 different CPU core, and the CPU sleep state modes and RT-patched
 kernels.
 
-| Driver   | Test   | core   | time-delay avg | min      | max         | System |
-|----------+--------+--------+----------------+----------+-------------+--------|
-| igc      | spin   | same   | 1575 ns        | 849 ns   | 2123 ns     | A      |
-| igc      | spin   | remote | 2639 ns        | 2337 ns  | 4019 ns     | A      |
-| igc      | wakeup | same   | 22881 ns       | 21190 ns | 30619 ns    | A      |
-| igc      | wakeup | remote | 50353 ns       | 47420 ns | 56156 ns    | A      |
-|----------+--------+--------+----------------+----------+-------------+--------|
-| conf upd |        |        |                |          | no C-states | *B*    |
-|----------+--------+--------+----------------+----------+-------------+--------|
-| igc      | spin   | same   | 1402 ns        | 805 ns   | 2867 ns     | B      |
-| igc      | spin   | remote | 1056 ns        | 419 ns   | 2798 ns     | B      |
-| igc      | wakeup | same   | 3177 ns        | 2210 ns  | 9136 ns     | B      |
-| igc      | wakeup | remote | 4095 ns        | 3029 ns  | 10595 ns    | B      |
-|----------+--------+--------+----------------+----------+-------------+--------|
+| Driver/HW | Test   | core   | time-delay avg | min      | max         | System |
+|-----------+--------+--------+----------------+----------+-------------+--------|
+| igc/i225  | spin   | same   | 1575 ns        | 849 ns   | 2123 ns     | A      |
+| igc/i225  | spin   | remote | 2639 ns        | 2337 ns  | 4019 ns     | A      |
+| igc/i225  | wakeup | same   | 22881 ns       | 21190 ns | 30619 ns    | A      |
+| igc/i225  | wakeup | remote | 50353 ns       | 47420 ns | 56156 ns    | A      |
+|-----------+--------+--------+----------------+----------+-------------+--------|
+| conf upd  |        |        |                |          | no C-states | *B*    |
+|-----------+--------+--------+----------------+----------+-------------+--------|
+| igc/i225  | spin   | same   | 1402 ns        | 805 ns   | 2867 ns     | B      |
+| igc/i225  | spin   | remote | 1056 ns        | 419 ns   | 2798 ns     | B      |
+| igc/i225  | wakeup | same   | 3177 ns        | 2210 ns  | 9136 ns     | B      |
+| igc/i225  | wakeup | remote | 4095 ns        | 3029 ns  | 10595 ns    | B      |
+|-----------+--------+--------+----------------+----------+-------------+--------|
 
 The latency is affected a lot by CPUs power-saving states, which can
 be limited globally by changing =/dev/cpu_dma_latency=. (See section
@@ -109,12 +109,12 @@ latency-performance= thus other tunings might also have happened)
 System *RT1* have a Real-Time patched kernel, and =cpu_dma_latency=
 have no effect (likely due to kernel config).
 
-| Driver   | Test   | core   | time-delay avg | min     | max     | System |
-|----------+--------+--------+----------------+---------+---------+--------|
-| igb/i210 | spin   | same   | 2577 ns        | 2129 ns | 4155 ns | RT1    |
-| igb/i210 | spin   | remote | 788 ns         | 551 ns  | 1473 ns | RT1    |
-| igb/i210 | wakeup | same   | 6209 ns        | 5644 ns | 8178 ns | RT1    |
-| igb/i210 | wakeup | remote | 5239 ns        | 4463 ns | 7390 ns | RT1    |
+| Driver/HW | Test   | core   | time-delay avg | min     | max     | System |
+|-----------+--------+--------+----------------+---------+---------+--------|
+| igb/i210  | spin   | same   | 2577 ns        | 2129 ns | 4155 ns | RT1    |
+| igb/i210  | spin   | remote | 788 ns         | 551 ns  | 1473 ns | RT1    |
+| igb/i210  | wakeup | same   | 6209 ns        | 5644 ns | 8178 ns | RT1    |
+| igb/i210  | wakeup | remote | 5239 ns        | 4463 ns | 7390 ns | RT1    |
 
 
 Systems table:

--- a/AF_XDP-interaction/README.org
+++ b/AF_XDP-interaction/README.org
@@ -90,17 +90,16 @@ kernels.
 | igc    | spin   | remote | 2639 ns        | 2337 ns  | 4019 ns  | A      |
 | igc    | wakeup | same   | 22881 ns       | 21190 ns | 30619 ns | A      |
 | igc    | wakeup | remote | 50353 ns       | 47420 ns | 56156 ns | A      |
+|--------+--------+--------+----------------+----------+----------+--------|
 | igc    | wakeup | same   | 3177 ns        | 2210 ns  | 9136 ns  | B      |
 | igc    | wakeup | remote | 4095 ns        | 3029 ns  | 10595 ns | B      |
 |        |        |        |                |          |          |        |
 
 The latency is affected a lot by CPUs power-saving states, which can
 be limited globally by changing =/dev/cpu_dma_latency=. (See section
-below).
-
-The main difference between system *A* and *B* is that
+below). The main difference between system *A* and *B* is that
 'cpu_dma_latency' have been changed to such a low value that CPU
-doesn't use C-states.  . (Side-note: used tool =tuned-adm profile
+doesn't use C-states. (Side-note: used tool =tuned-adm profile
 latency-performance= thus other tunings might also have happened)
 
 Systems table:

--- a/AF_XDP-interaction/README.org
+++ b/AF_XDP-interaction/README.org
@@ -93,6 +93,8 @@ kernels.
 |----------+--------+--------+----------------+----------+-------------+--------|
 | conf upd |        |        |                |          | no C-states | *B*    |
 |----------+--------+--------+----------------+----------+-------------+--------|
+| igc      | spin   | same   | 1402 ns        | 805 ns   | 2867 ns     | B      |
+| igc      | spin   | remote | 1056 ns        | 419 ns   | 2798 ns     | B      |
 | igc      | wakeup | same   | 3177 ns        | 2210 ns  | 9136 ns     | B      |
 | igc      | wakeup | remote | 4095 ns        | 3029 ns  | 10595 ns    | B      |
 |          |        |        |                |          |             |        |
@@ -105,11 +107,11 @@ doesn't use C-states. (Side-note: used tool =tuned-adm profile
 latency-performance= thus other tunings might also have happened)
 
 Systems table:
-| Name | CPU               | Kernel          | Kernel options | cpu_dma_latency      |
-|------+-------------------+-----------------+----------------+----------------------|
-| A    | E5-1650 v4 3.6GHz | 5.15.0-net-next | PREEMPT        | 2 ms (2000000000 ns) |
-| B    | E5-1650 v4 3.6GHz | 5.15.0-net-next | PREEMPT        | 2 ns                 |
-|      |                   |                 |                |                      |
+| Name | CPU @ GHz            | Kernel          | Kernel options | cpu_dma_latency      |
+|------+----------------------+-----------------+----------------+----------------------|
+| A    | E5-1650 v4 @ 3.60GHz | 5.15.0-net-next | PREEMPT        | 2 ms (2000000000 ns) |
+| B    | E5-1650 v4 @ 3.60GHz | 5.15.0-net-next | PREEMPT        | 2 ns                 |
+|      |                      |                 |                |                      |
 
 ** C-states wakeup time
 

--- a/AF_XDP-interaction/README.org
+++ b/AF_XDP-interaction/README.org
@@ -65,6 +65,14 @@ or using the spin-mode, and effects of userspace running on same or a
 different CPU core, and effects of CPU sleep state modes and
 RT-patched kernels.
 
+| Driver | Test   | time-delay       | core   | CPU/system     | kernel          |
+|--------+--------+------------------+--------+----------------+-----------------|
+| igc    | wakeup | 50652 ns         | remote | E5-1650 3.6GHz | 5.15.0-net-next |
+| igc    | wakeup | 22053 ns         | same   | E5-1650 3.6GHz | 5.15.0-net-next |
+| igc    | spin   | 2990 ns          | remote | E5-1650 3.6GHz | 5.15.0-net-next |
+| igc    | spin   | (jitter) 1582 ns | remote | E5-1650 3.6GHz | 5.15.0-net-next |
+|        |        |                  |        |                |                 |
+
 The real value for the application use-case (in question) is that it
 doesn't need to waste so much CPU time spinning to get this accurate
 timestamps for packet arrival.  The application only need timestamps

--- a/AF_XDP-interaction/README.org
+++ b/AF_XDP-interaction/README.org
@@ -84,16 +84,18 @@ using the spin-mode, and effects of userspace running on same or a
 different CPU core, and the CPU sleep state modes and RT-patched
 kernels.
 
-| Driver | Test   | core   | time-delay avg | min      | max      | System |
-|--------+--------+--------+----------------+----------+----------+--------|
-| igc    | spin   | same   | 1575 ns        | 849 ns   | 2123 ns  | A      |
-| igc    | spin   | remote | 2639 ns        | 2337 ns  | 4019 ns  | A      |
-| igc    | wakeup | same   | 22881 ns       | 21190 ns | 30619 ns | A      |
-| igc    | wakeup | remote | 50353 ns       | 47420 ns | 56156 ns | A      |
-|--------+--------+--------+----------------+----------+----------+--------|
-| igc    | wakeup | same   | 3177 ns        | 2210 ns  | 9136 ns  | B      |
-| igc    | wakeup | remote | 4095 ns        | 3029 ns  | 10595 ns | B      |
-|        |        |        |                |          |          |        |
+| Driver   | Test   | core   | time-delay avg | min      | max         | System |
+|----------+--------+--------+----------------+----------+-------------+--------|
+| igc      | spin   | same   | 1575 ns        | 849 ns   | 2123 ns     | A      |
+| igc      | spin   | remote | 2639 ns        | 2337 ns  | 4019 ns     | A      |
+| igc      | wakeup | same   | 22881 ns       | 21190 ns | 30619 ns    | A      |
+| igc      | wakeup | remote | 50353 ns       | 47420 ns | 56156 ns    | A      |
+|----------+--------+--------+----------------+----------+-------------+--------|
+| conf upd |        |        |                |          | no C-states | *B*    |
+|----------+--------+--------+----------------+----------+-------------+--------|
+| igc      | wakeup | same   | 3177 ns        | 2210 ns  | 9136 ns     | B      |
+| igc      | wakeup | remote | 4095 ns        | 3029 ns  | 10595 ns    | B      |
+|          |        |        |                |          |             |        |
 
 The latency is affected a lot by CPUs power-saving states, which can
 be limited globally by changing =/dev/cpu_dma_latency=. (See section

--- a/AF_XDP-interaction/README.org
+++ b/AF_XDP-interaction/README.org
@@ -65,13 +65,19 @@ or using the spin-mode, and effects of userspace running on same or a
 different CPU core, and effects of CPU sleep state modes and
 RT-patched kernels.
 
-| Driver | Test   | time-delay       | core   | CPU/system     | kernel          |
-|--------+--------+------------------+--------+----------------+-----------------|
-| igc    | wakeup | 50652 ns         | remote | E5-1650 3.6GHz | 5.15.0-net-next |
-| igc    | wakeup | 22053 ns         | same   | E5-1650 3.6GHz | 5.15.0-net-next |
-| igc    | spin   | 2990 ns          | remote | E5-1650 3.6GHz | 5.15.0-net-next |
-| igc    | spin   | (jitter) 1582 ns | remote | E5-1650 3.6GHz | 5.15.0-net-next |
-|        |        |                  |        |                |                 |
+| Driver | Test   | core   | time-delay | min |   | System    |
+|--------+--------+--------+------------+-----+---+-----------|
+| igc    | wakeup | same   | 22053 ns   |     |   | broadwell |
+| igc    | wakeup | remote | 50652 ns   |     |   | broadwell |
+| igc    | spin   | same   | 1582 ns    |     |   | broadwell |
+| igc    | spin   | remote | 2990 ns    |     |   | broadwell |
+|        |        |        |            |     |   |           |
+
+Systems table
+| Name      | CPU               | Kernel          | Kernel options |
+|-----------+-------------------+-----------------+----------------|
+| broadwell | E5-1650 v4 3.6GHz | 5.15.0-net-next | PREEMPT        |
+|           |                   |                 |                |
 
 The real value for the application use-case (in question) is that it
 doesn't need to waste so much CPU time spinning to get this accurate

--- a/AF_XDP-interaction/README.org
+++ b/AF_XDP-interaction/README.org
@@ -53,6 +53,28 @@ size (and offsets) of all data-structures.  Thus, we can deduce the
 size of the metadata area, when knowing the =bpf_id=, which by placing
 it as the last member is in a known location.
 
+* Why is XDP RX-timestamp essential for AF_XDP
+
+In this example, the kernel-side XDP BPF-prog (file:af_xdp_kern.c)
+take a timestamp (=bpf_ktime_get_ns()=) and stores it in the metadata
+as an XDP-hint.  This make it possible to measure the time-delay from
+XDP softirq execution and when AF_XDP gets the packet out of its
+RX-ring.  It is some interesting data-points, as there is (obviously)
+big difference between waiting for a wakeup (via =poll= or =select=)
+or using the spin-mode, and effects of userspace running on same or a
+different CPU core, and effects of CPU sleep state modes and
+RT-patched kernels.
+
+The real value for the application use-case (in question) is that it
+doesn't need to waste so much CPU time spinning to get this accurate
+timestamps for packet arrival.  The application only need timestamps
+on the synchronization traffic ([[https://en.wikipedia.org/wiki/TTEthernet][PCF frames]]).
+The other Time-triggered traffic arrives at a deterministic time
+(according to established time schedule based on PCF).  The
+application prefers to bulk receive the Time-triggered traffic, which
+can be acheived by waking up at the right time (according to
+time-schedule).  Thus, it would be wasteful to busy-poll with the only
+purpose of getting better timing accuracy for the PCF frames.
 
 * AF_XDP documentation
 

--- a/AF_XDP-interaction/README.org
+++ b/AF_XDP-interaction/README.org
@@ -59,25 +59,7 @@ In this example, the kernel-side XDP BPF-prog (file:af_xdp_kern.c)
 take a timestamp (=bpf_ktime_get_ns()=) and stores it in the metadata
 as an XDP-hint.  This make it possible to measure the time-delay from
 XDP softirq execution and when AF_XDP gets the packet out of its
-RX-ring.  It is some interesting data-points, as there is (obviously)
-big difference between waiting for a wakeup (via =poll= or =select=)
-or using the spin-mode, and effects of userspace running on same or a
-different CPU core, and effects of CPU sleep state modes and
-RT-patched kernels.
-
-| Driver | Test   | core   | time-delay | min |   | System    |
-|--------+--------+--------+------------+-----+---+-----------|
-| igc    | wakeup | same   | 22053 ns   |     |   | broadwell |
-| igc    | wakeup | remote | 50652 ns   |     |   | broadwell |
-| igc    | spin   | same   | 1582 ns    |     |   | broadwell |
-| igc    | spin   | remote | 2990 ns    |     |   | broadwell |
-|        |        |        |            |     |   |           |
-
-Systems table
-| Name      | CPU               | Kernel          | Kernel options |
-|-----------+-------------------+-----------------+----------------|
-| broadwell | E5-1650 v4 3.6GHz | 5.15.0-net-next | PREEMPT        |
-|           |                   |                 |                |
+RX-ring. (See Interesting data-points below)
 
 The real value for the application use-case (in question) is that it
 doesn't need to waste so much CPU time spinning to get this accurate
@@ -89,6 +71,72 @@ application prefers to bulk receive the Time-triggered traffic, which
 can be acheived by waking up at the right time (according to
 time-schedule).  Thus, it would be wasteful to busy-poll with the only
 purpose of getting better timing accuracy for the PCF frames.
+
+** Interesting data-points
+
+The time-delay from XDP softirq execution and to when AF_XDP gets the
+packet, give us some interesting data-points, and tell us about system
+latency and sleep behavior.
+
+The data-points are interesting, as there is (obviously) big
+difference between waiting for a wakeup (via =poll= or =select=) or
+using the spin-mode, and effects of userspace running on same or a
+different CPU core, and the CPU sleep state modes and RT-patched
+kernels.
+
+| Driver | Test   | core   | time-delay avg | min      | max      | System |
+|--------+--------+--------+----------------+----------+----------+--------|
+| igc    | spin   | same   | 1575 ns        | 849 ns   | 2123 ns  | A      |
+| igc    | spin   | remote | 2639 ns        | 2337 ns  | 4019 ns  | A      |
+| igc    | wakeup | same   | 22881 ns       | 21190 ns | 30619 ns | A      |
+| igc    | wakeup | remote | 50353 ns       | 47420 ns | 56156 ns | A      |
+| igc    | wakeup | same   | 3177 ns        | 2210 ns  | 9136 ns  | B      |
+| igc    | wakeup | remote | 4095 ns        | 3029 ns  | 10595 ns | B      |
+|        |        |        |                |          |          |        |
+
+The latency is affected a lot by CPUs power-saving states, which can
+be limited globally by changing =/dev/cpu_dma_latency=. (See section
+below).
+
+The main difference between system *A* and *B* is that
+'cpu_dma_latency' have been changed to such a low value that CPU
+doesn't use C-states.  . (Side-note: used tool =tuned-adm profile
+latency-performance= thus other tunings might also have happened)
+
+Systems table:
+| Name | CPU               | Kernel          | Kernel options | cpu_dma_latency      |
+|------+-------------------+-----------------+----------------+----------------------|
+| A    | E5-1650 v4 3.6GHz | 5.15.0-net-next | PREEMPT        | 2 ms (2000000000 ns) |
+| B    | E5-1650 v4 3.6GHz | 5.15.0-net-next | PREEMPT        | 2 ns                 |
+|      |                   |                 |                |                      |
+
+** C-states wakeup time
+
+It is possible to view the systems time (in usec) to wakeup from a
+certain C-state, via below =grep= command:
+
+#+BEGIN_SRC sh
+# grep -H . /sys/devices/system/cpu/cpu0/cpuidle/*/latency
+/sys/devices/system/cpu/cpu0/cpuidle/state0/latency:0
+/sys/devices/system/cpu/cpu0/cpuidle/state1/latency:2
+/sys/devices/system/cpu/cpu0/cpuidle/state2/latency:10
+/sys/devices/system/cpu/cpu0/cpuidle/state3/latency:40
+/sys/devices/system/cpu/cpu0/cpuidle/state4/latency:133
+#+END_SRC
+
+** Meaning of cpu_dma_latency
+
+The global CPU latency limit is controlled via the file
+=/dev/cpu_dma_latency=, which contains a binary value (interpreted as
+a signed 32-bit integer).  Reading contents can be annoying from the
+command line, so lets provide a practical example:
+
+Reading =/dev/cpu_dma_latency=:
+#+begin_src sh
+$ sudo hexdump --format '"%d\n"' /dev/cpu_dma_latency
+2000000000
+#+end_src
+
 
 * AF_XDP documentation
 

--- a/AF_XDP-interaction/README.org
+++ b/AF_XDP-interaction/README.org
@@ -97,7 +97,7 @@ kernels.
 | igc      | spin   | remote | 1056 ns        | 419 ns   | 2798 ns     | B      |
 | igc      | wakeup | same   | 3177 ns        | 2210 ns  | 9136 ns     | B      |
 | igc      | wakeup | remote | 4095 ns        | 3029 ns  | 10595 ns    | B      |
-|          |        |        |                |          |             |        |
+|----------+--------+--------+----------------+----------+-------------+--------|
 
 The latency is affected a lot by CPUs power-saving states, which can
 be limited globally by changing =/dev/cpu_dma_latency=. (See section
@@ -106,11 +106,23 @@ below). The main difference between system *A* and *B* is that
 doesn't use C-states. (Side-note: used tool =tuned-adm profile
 latency-performance= thus other tunings might also have happened)
 
+System *RT1* have a Real-Time patched kernel, and =cpu_dma_latency=
+have no effect (likely due to kernel config).
+
+| Driver   | Test   | core   | time-delay avg | min     | max     | System |
+|----------+--------+--------+----------------+---------+---------+--------|
+| igb/i210 | spin   | same   | 2577 ns        | 2129 ns | 4155 ns | RT1    |
+| igb/i210 | spin   | remote | 788 ns         | 551 ns  | 1473 ns | RT1    |
+| igb/i210 | wakeup | same   | 6209 ns        | 5644 ns | 8178 ns | RT1    |
+| igb/i210 | wakeup | remote | 5239 ns        | 4463 ns | 7390 ns | RT1    |
+
+
 Systems table:
 | Name | CPU @ GHz            | Kernel          | Kernel options | cpu_dma_latency      |
 |------+----------------------+-----------------+----------------+----------------------|
 | A    | E5-1650 v4 @ 3.60GHz | 5.15.0-net-next | PREEMPT        | 2 ms (2000000000 ns) |
 | B    | E5-1650 v4 @ 3.60GHz | 5.15.0-net-next | PREEMPT        | 2 ns                 |
+| RT1  | i5-6500TE @ 2.30GHz  | 5.13.0-rt1+     | PREEMPT_RT     | 2ms, but no-effect   |
 |      |                      |                 |                |                      |
 
 ** C-states wakeup time

--- a/AF_XDP-interaction/af_xdp_kern.c
+++ b/AF_XDP-interaction/af_xdp_kern.c
@@ -46,6 +46,7 @@ struct xdp_hints_mark {
 
 struct xdp_hints_rx_time {
 	__u64 rx_ktime;
+	__u32 xdp_rx_cpu;
 	__u32 btf_id;
 } __attribute__((aligned(4))) __attribute__((packed));
 
@@ -74,6 +75,7 @@ int meta_add_rx_time(struct xdp_md *ctx)
 		return -2;
 
 	meta->rx_ktime = bpf_ktime_get_ns();
+	meta->xdp_rx_cpu = bpf_get_smp_processor_id();
 	/* Userspace can identify struct used by BTF id */
 	meta->btf_id = bpf_core_type_id_local(struct xdp_hints_rx_time);
 

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -766,6 +766,9 @@ static void handle_receive_packets(struct xsk_socket_info *xsk)
 
 	/* Do we need to wake up the kernel for transmission */
 	complete_tx(xsk);
+
+	if (verbose && rcvd > 1)
+		printf("%s(): RX batch %d packets (i:%d)\n", __func__, rcvd, i);
   }
 
 static void rx_and_process(struct config *cfg,

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -490,6 +490,10 @@ static int print_meta_info_time(uint8_t *pkt, struct xdp_hints_rx_time *meta,
 	__u64 diff;
 	int err;
 
+	static boot first = true;
+	static int max;
+	static int min;
+
 	/* API doesn't involve allocations to access BTF struct member */
 	err = xsk_btf__read((void **)&rx_ktime_ptr, sizeof(*rx_ktime_ptr),
 			    &meta->rx_ktime, meta->xbi, pkt);


### PR DESCRIPTION
Describe **why** XDP RX-timestamps are essential for AF_XDP.

Also add some data-point results from different systems, measuring the latency between RX-softirq and AF_XDP processing.

Even-though, as explained, this latency is not important to the real use-case in question. The essential part is moving the time-stamping to XDP, as it makes is possible for the application to relax the latency requirements and process RX-packets in bulk.
