### PR TITLE
PPing - Improve map cleanup

### DIFF
--- a/pping/Makefile
+++ b/pping/Makefile
@@ -4,7 +4,7 @@ USER_TARGETS   := pping
 BPF_TARGETS    := pping_kern
 
 LDLIBS     += -pthread
-EXTRA_DEPS += pping.h
+EXTRA_DEPS += pping.h pping_debug_cleanup.h
 
 LIB_DIR = ../lib
 

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -23,16 +23,6 @@ static const char *__doc__ =
 #include "json_writer.h"
 #include "pping.h" //common structs for user-space and BPF parts
 
-#define NS_PER_SECOND 1000000000UL
-#define NS_PER_MS 1000000UL
-#define MS_PER_S 1000UL
-#define S_PER_DAY (24*3600UL)
-
-#define TIMESTAMP_LIFETIME                                                     \
-	(10 * NS_PER_SECOND) // Clear out packet timestamps if they're over 10 seconds
-#define FLOW_LIFETIME                                                          \
-	(300 * NS_PER_SECOND) // Clear out flows if they're inactive over 300 seconds
-
 #define PERF_BUFFER_PAGES 64 // Related to the perf-buffer size?
 #define PERF_POLL_TIMEOUT_MS 100
 
@@ -64,9 +54,9 @@ enum PPING_OUTPUT_FORMAT {
 // Also keeps information about the thread in which the cleanup function runs
 struct map_cleanup_args {
 	pthread_t tid;
+	struct bpf_link *tsclean_link;
+	struct bpf_link *flowclean_link;
 	__u64 cleanup_interval;
-	int packet_map_fd;
-	int flow_map_fd;
 	bool valid_thread;
 };
 
@@ -79,6 +69,8 @@ struct pping_config {
 	char *object_path;
 	char *ingress_prog;
 	char *egress_prog;
+	char *cleanup_ts_prog;
+	char *cleanup_flow_prog;
 	char *packet_map;
 	char *flow_map;
 	char *event_map;
@@ -480,6 +472,61 @@ static int tc_detach(int ifindex, enum bpf_tc_attach_point attach_point,
 }
 
 /*
+ * Attach program prog_name (of typer iter/bpf_map_elem) from obj to map_name
+ */
+static int iter_map_attach(struct bpf_object *obj, const char *prog_name,
+			   const char *map_name, struct bpf_link **link)
+{
+	struct bpf_program *prog;
+	struct bpf_link *linkptr;
+	union bpf_iter_link_info linfo = { 0 };
+	int map_fd, err;
+	DECLARE_LIBBPF_OPTS(bpf_iter_attach_opts, iter_opts,
+			    .link_info = &linfo,
+			    .link_info_len = sizeof(linfo));
+
+	map_fd = bpf_object__find_map_fd_by_name(obj, map_name);
+	if (map_fd < 0)
+		return map_fd;
+	linfo.map.map_fd = map_fd;
+
+	prog = bpf_object__find_program_by_name(obj, prog_name);
+	err = libbpf_get_error(prog);
+	if (err)
+		return err;
+
+	linkptr = bpf_program__attach_iter(prog, &iter_opts);
+	err = libbpf_get_error(linkptr);
+	if (err)
+		return err;
+
+	*link = linkptr;
+	return 0;
+}
+
+/*
+ * Execute the iter/bpf_map_elem program attached through link on map elements
+ */
+static int iter_map_execute(struct bpf_link *link)
+{
+	int iter_fd, err;
+	char buf[64];
+
+	if (!link)
+		return -EINVAL;
+
+	iter_fd = bpf_iter_create(bpf_link__fd(link));
+	if (iter_fd < 0)
+		return iter_fd;
+
+	while ((err = read(iter_fd, &buf, sizeof(buf))) > 0)
+		;
+
+	close(iter_fd);
+	return err;
+}
+
+/*
  * Returns time as nanoseconds in a single __u64.
  * On failure, the value 0 is returned (and errno will be set).
  */
@@ -492,111 +539,32 @@ static __u64 get_time_ns(clockid_t clockid)
 	return (__u64)t.tv_sec * NS_PER_SECOND + (__u64)t.tv_nsec;
 }
 
-static bool packet_ts_timeout(void *key_ptr, void *val_ptr, __u64 now)
-{
-	__u64 ts = *(__u64 *)val_ptr;
-	if (now > ts && now - ts > TIMESTAMP_LIFETIME)
-		return true;
-	return false;
-}
-
-static bool flow_timeout(void *key_ptr, void *val_ptr, __u64 now)
-{
-	struct flow_event fe;
-	struct flow_state *f_state = val_ptr;
-
-	if (now > f_state->last_timestamp &&
-	    now - f_state->last_timestamp > FLOW_LIFETIME) {
-		if (print_event_func && f_state->has_opened) {
-			fe.event_type = EVENT_TYPE_FLOW;
-			fe.timestamp = now;
-			reverse_flow(&fe.flow, key_ptr);
-			fe.flow_event_type = FLOW_EVENT_CLOSING;
-			fe.reason = EVENT_REASON_FLOW_TIMEOUT;
-			fe.source = EVENT_SOURCE_USERSPACE;
-			print_event_func((union pping_event *)&fe);
-		}
-		return true;
-	}
-	return false;
-}
-
-/*
- * Loops through all entries in a map, running del_decision_func(value, time)
- * on every entry, and deleting those for which it returns true.
- * On sucess, returns the number of entries deleted, otherwise returns the
- * (negative) error code.
- */
-//TODO - maybe add some pointer to arguments for del_decision_func?
-static int clean_map(int map_fd, size_t key_size, size_t value_size,
-		     bool (*del_decision_func)(void *, void *, __u64))
-{
-	int removed = 0;
-	void *key, *prev_key, *value;
-	bool delete_prev = false;
-	__u64 now_nsec = get_time_ns(CLOCK_MONOTONIC);
-
-#ifdef DEBUG
-	int entries = 0;
-	__u64 duration;
-#endif
-
-	if (now_nsec == 0)
-		return -errno;
-
-	key = malloc(key_size);
-	prev_key = malloc(key_size);
-	value = malloc(value_size);
-	if (!key || !prev_key || !value) {
-		removed = -ENOMEM;
-		goto cleanup;
-	}
-
-	// Cannot delete current key because then loop will reset, see https://www.bouncybouncy.net/blog/bpf_map_get_next_key-pitfalls/
-	while (bpf_map_get_next_key(map_fd, prev_key, key) == 0) {
-		if (delete_prev) {
-			bpf_map_delete_elem(map_fd, prev_key);
-			removed++;
-			delete_prev = false;
-		}
-
-		if (bpf_map_lookup_elem(map_fd, key, value) == 0)
-			delete_prev = del_decision_func(key, value, now_nsec);
-#ifdef DEBUG
-		entries++;
-#endif
-		memcpy(prev_key, key, key_size);
-	}
-	if (delete_prev) {
-		bpf_map_delete_elem(map_fd, prev_key);
-		removed++;
-	}
-#ifdef DEBUG
-	duration = get_time_ns(CLOCK_MONOTONIC) - now_nsec;
-	fprintf(stderr,
-		"%d: Gone through %d entries and removed %d of them in %llu.%09llu s\n",
-		map_fd, entries, removed, duration / NS_PER_SECOND,
-		duration % NS_PER_SECOND);
-#endif
-cleanup:
-	free(key);
-	free(prev_key);
-	free(value);
-	return removed;
-}
-
 static void *periodic_map_cleanup(void *args)
 {
 	struct map_cleanup_args *argp = args;
 	struct timespec interval;
 	interval.tv_sec = argp->cleanup_interval / NS_PER_SECOND;
 	interval.tv_nsec = argp->cleanup_interval % NS_PER_SECOND;
+	char buf[256];
+	int err;
 
 	while (keep_running) {
-		clean_map(argp->packet_map_fd, sizeof(struct packet_id),
-			  sizeof(__u64), packet_ts_timeout);
-		clean_map(argp->flow_map_fd, sizeof(struct network_tuple),
-			  sizeof(struct flow_state), flow_timeout);
+		err = iter_map_execute(argp->tsclean_link);
+		if (err) {
+			// Running in separate thread so can't use get_libbpf_strerror
+			libbpf_strerror(err, buf, sizeof(buf));
+			fprintf(stderr,
+				"Error while cleaning timestamp map: %s\n",
+				buf);
+		}
+
+		err = iter_map_execute(argp->flowclean_link);
+		if (err) {
+			libbpf_strerror(err, buf, sizeof(buf));
+			fprintf(stderr, "Error while cleaning flow map: %s\n",
+				buf);
+		}
+
 		nanosleep(&interval, NULL);
 	}
 	pthread_exit(NULL);
@@ -697,8 +665,8 @@ static const char *eventsource_to_str(enum flow_event_source es)
 		return "src";
 	case EVENT_SOURCE_PKT_DEST:
 		return "dest";
-	case EVENT_SOURCE_USERSPACE:
-		return "userspace-cleanup";
+	case EVENT_SOURCE_GC:
+		return "garbage collection";
 	default:
 		return "unknown";
 	}
@@ -979,7 +947,7 @@ ingress_err:
 static int setup_periodical_map_cleaning(struct bpf_object *obj,
 					 struct pping_config *config)
 {
-	int map_fd, err;
+	int err;
 
 	if (config->clean_args.valid_thread) {
 		fprintf(stderr,
@@ -992,21 +960,23 @@ static int setup_periodical_map_cleaning(struct bpf_object *obj,
 		return 0;
 	}
 
-	map_fd = bpf_object__find_map_fd_by_name(obj, config->packet_map);
-	if (map_fd < 0) {
-		fprintf(stderr, "Could not get file descriptor of map %s: %s\n",
-			config->packet_map, get_libbpf_strerror(map_fd));
-		return map_fd;
+	err = iter_map_attach(obj, config->cleanup_ts_prog, config->packet_map,
+			      &config->clean_args.tsclean_link);
+	if (err) {
+		fprintf(stderr,
+			"Failed attaching cleanup program to timestamp map: %s\n",
+			get_libbpf_strerror(err));
+		return err;
 	}
-	config->clean_args.packet_map_fd = map_fd;
 
-	map_fd = bpf_object__find_map_fd_by_name(obj, config->flow_map);
-	if (map_fd < 0) {
-		fprintf(stderr, "Could not get file descriptor of map %s: %s\n",
-			config->flow_map, get_libbpf_strerror(map_fd));
-		return map_fd;
+	err = iter_map_attach(obj, config->cleanup_flow_prog, config->flow_map,
+			      &config->clean_args.flowclean_link);
+	if (err) {
+		fprintf(stderr,
+			"Failed attaching cleanup program to flow map: %s\n",
+			get_libbpf_strerror(err));
+		goto destroy_ts_link;
 	}
-	config->clean_args.flow_map_fd = map_fd;
 
 	err = pthread_create(&config->clean_args.tid, NULL,
 			     periodic_map_cleanup, &config->clean_args);
@@ -1014,11 +984,17 @@ static int setup_periodical_map_cleaning(struct bpf_object *obj,
 		fprintf(stderr,
 			"Failed starting thread to perform periodic map cleanup: %s\n",
 			get_libbpf_strerror(err));
-		return err;
+		goto destroy_links;
 	}
 
 	config->clean_args.valid_thread = true;
 	return 0;
+
+destroy_links:
+	bpf_link__destroy(config->clean_args.flowclean_link);
+destroy_ts_link:
+	bpf_link__destroy(config->clean_args.tsclean_link);
+	return err;
 }
 
 int main(int argc, char *argv[])
@@ -1039,6 +1015,8 @@ int main(int argc, char *argv[])
 		.object_path = "pping_kern.o",
 		.ingress_prog = "pping_xdp_ingress",
 		.egress_prog = "pping_tc_egress",
+		.cleanup_ts_prog = "tsmap_cleanup",
+		.cleanup_flow_prog = "flowmap_cleanup",
 		.packet_map = "packet_ts",
 		.flow_map = "flow_state",
 		.event_map = "events",
@@ -1145,6 +1123,9 @@ int main(int argc, char *argv[])
 	if (config.clean_args.valid_thread) {
 		pthread_cancel(config.clean_args.tid);
 		pthread_join(config.clean_args.tid, NULL);
+
+		bpf_link__destroy(config.clean_args.tsclean_link);
+		bpf_link__destroy(config.clean_args.flowclean_link);
 	}
 
 cleanup_perf_buffer:

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -20,6 +20,7 @@ typedef __u64 fixpoint64;
 #define EVENT_TYPE_FLOW 1
 #define EVENT_TYPE_RTT 2
 #define EVENT_TYPE_MAP_FULL 3
+#define EVENT_TYPE_MAP_CLEAN 4
 
 enum __attribute__((__packed__)) flow_event_type {
 	FLOW_EVENT_NONE,
@@ -103,12 +104,14 @@ struct packet_id {
 	__u32 identifier; //tsval for TCP packets
 };
 
+
 /*
  * Events that can be passed from the BPF-programs to the user space
  * application.
  * The initial event_type memeber is used to allow multiplexing between
- * different event types in a single perf buffer. Memebers up to and including
- * flow are identical for all event types.
+ * different event types in a single perf buffer. Memebers event_type and
+ * timestamp are common among all event types, and flow is common for
+ * rtt_event, flow_event and map_full_event.
  */
 
 /*
@@ -156,11 +159,33 @@ struct map_full_event {
 	__u8 reserved[3];
 };
 
+/*
+ * Struct for storing various debug-information about the map cleaning process.
+ * The last_* members contain information from the last clean-cycle, whereas the
+ * tot_* entires contain cumulative stats from all clean cycles.
+ */
+struct map_clean_event {
+	__u64 event_type;
+	__u64 timestamp;
+	__u64 tot_runtime;
+	__u64 tot_processed_entries;
+	__u64 tot_timeout_del;
+	__u64 tot_auto_del;
+	__u64 last_runtime;
+	__u32 last_processed_entries;
+	__u32 last_timeout_del;
+	__u32 last_auto_del;
+	__u32 clean_cycles;
+	enum pping_map map;
+	__u8 reserved[7];
+};
+
 union pping_event {
 	__u64 event_type;
 	struct rtt_event rtt_event;
 	struct flow_event flow_event;
 	struct map_full_event map_event;
+	struct map_clean_event map_clean_event;
 };
 
 #endif

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -6,6 +6,11 @@
 #include <linux/in6.h>
 #include <stdbool.h>
 
+#define NS_PER_SECOND 1000000000UL
+#define NS_PER_MS 1000000UL
+#define MS_PER_S 1000UL
+#define S_PER_DAY (24*3600UL)
+
 typedef __u64 fixpoint64;
 #define FIXPOINT_SHIFT 16
 #define DOUBLE_TO_FIXPOINT(X) ((fixpoint64)((X) * (1UL << FIXPOINT_SHIFT)))
@@ -35,7 +40,7 @@ enum __attribute__((__packed__)) flow_event_reason {
 enum __attribute__((__packed__)) flow_event_source {
 	EVENT_SOURCE_PKT_SRC,
 	EVENT_SOURCE_PKT_DEST,
-	EVENT_SOURCE_USERSPACE
+	EVENT_SOURCE_GC
 };
 
 enum __attribute__((__packed__)) pping_map {
@@ -157,20 +162,5 @@ union pping_event {
 	struct flow_event flow_event;
 	struct map_full_event map_event;
 };
-
-/*
- * Convenience function for getting the corresponding reverse flow.
- * PPing needs to keep track of flow in both directions, and sometimes
- * also needs to reverse the flow to report the "correct" (consistent
- * with Kathie's PPing) src and dest address.
- */
-static void reverse_flow(struct network_tuple *dest, struct network_tuple *src)
-{
-	dest->ipv = src->ipv;
-	dest->proto = src->proto;
-	dest->saddr = src->daddr;
-	dest->daddr = src->saddr;
-	dest->reserved = 0;
-}
 
 #endif

--- a/pping/pping_debug_cleanup.h
+++ b/pping/pping_debug_cleanup.h
@@ -1,0 +1,124 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef __PPING_DEBUG_CLEANUP_H
+#define __PPING_DEBUG_CLEANUP_H
+
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include "pping.h"
+
+/*
+ * Structs and functions that are only used for tracking the cleanup of the
+ * packet timestamp and flow state maps.
+
+ * Structs and contents of functions are guarded by ifdef DEBUGs to minimze
+ * overhead, and kept in this file to keep the normal pping-related code
+ * cleaner.
+ */
+
+#ifdef DEBUG
+
+/*
+ * Global entries with cleanup stats for each map (PPING_MAP_PACKETTS and
+ * PPING_MAP_FLOWSTATE). The last_* members keep track of how many entries
+ * that are deleted in the current cleaning cycle and are updated continuiously,
+ * whereas the tot_* entries keeps the cumulative stats but are only updated at
+ * the end of the current cleaning cycle.
+ */
+
+struct map_clean_stats {
+	__u64 start_time;
+	__u64 tot_runtime;
+	__u64 tot_processed_entries;
+	__u64 tot_timeout_del;
+	__u64 tot_auto_del;
+	__u64 last_runtime;
+	__u32 last_processed_entries;
+	__u32 last_timeout_del;
+	__u32 last_auto_del;
+	__u32 clean_cycles;
+};
+
+static volatile struct map_clean_stats clean_stats[2] = { 0 };
+
+#endif
+
+
+static __always_inline void debug_increment_autodel(enum pping_map map)
+{
+#ifdef DEBUG
+	clean_stats[map].last_auto_del += 1;
+#endif
+}
+
+static __always_inline void debug_increment_timeoutdel(enum pping_map map)
+{
+#ifdef DEBUG
+	clean_stats[map].last_timeout_del += 1;
+#endif
+}
+
+#ifdef DEBUG
+static __always_inline void
+send_map_clean_event(void *ctx, void *perf_buffer,
+		     volatile const struct map_clean_stats *map_stats,
+		     __u64 now, enum pping_map map)
+{
+	struct map_clean_event mce = {
+		.event_type = EVENT_TYPE_MAP_CLEAN,
+		.timestamp = now,
+		.tot_timeout_del = map_stats->tot_timeout_del,
+		.tot_auto_del = map_stats->tot_auto_del,
+		.tot_processed_entries = map_stats->tot_processed_entries,
+		.tot_runtime = map_stats->tot_runtime,
+		.last_timeout_del = map_stats->last_timeout_del,
+		.last_auto_del = map_stats->last_auto_del,
+		.last_processed_entries = map_stats->last_processed_entries,
+		.last_runtime = map_stats->last_runtime,
+		.clean_cycles = map_stats->clean_cycles,
+		.map = map,
+		.reserved = { 0 }
+	};
+
+	bpf_perf_event_output(ctx, perf_buffer, BPF_F_CURRENT_CPU, &mce,
+			      sizeof(mce));
+}
+#endif
+
+static __always_inline void
+debug_update_mapclean_stats(void *ctx, void *perf_buffer, bool final,
+			    __u64 seq_num, __u64 time, enum pping_map map)
+{
+#ifdef DEBUG
+	volatile struct map_clean_stats *map_stats = &clean_stats[map];
+
+	if (final) { // post final entry
+		if (map_stats->start_time) { // Non-empty map
+			map_stats->last_processed_entries = seq_num + 1;
+			map_stats->last_runtime = time - map_stats->start_time;
+		} else {
+			map_stats->last_processed_entries = 0;
+			map_stats->last_runtime = 0;
+		}
+
+		//update totals
+		map_stats->tot_runtime += map_stats->last_runtime;
+		map_stats->tot_processed_entries +=
+			map_stats->last_processed_entries;
+		map_stats->tot_timeout_del += map_stats->last_timeout_del;
+		map_stats->tot_auto_del += map_stats->last_auto_del;
+		map_stats->clean_cycles += 1;
+
+		send_map_clean_event(ctx, perf_buffer, map_stats, time, map);
+
+		// Reset for next clean cycle
+		map_stats->start_time = 0;
+		map_stats->last_timeout_del = 0;
+		map_stats->last_auto_del = 0;
+
+	} else if (seq_num == 0) { // mark first entry
+		map_stats->start_time = time;
+	}
+#endif
+}
+
+#endif


### PR DESCRIPTION
These commits moves the cleanup logic for stale entires from userspace to a BPF iter program. So instead of userspace periodically looping through the maps clearing out old entries, it only triggers the BPF programs periodically, and the BPF program iterates through all the entries removing  those which are considered old.

Also adds some slightly more complex logic for when an entry can be removed, for example ICMP flows and unopened TCP flows can be cleared faster than an open TCP flow, and timestamp entries with low RTTs can be cleared much faster than the static 10s limit.

All these commits were created with the changes from [PR#23](https://github.com/xdp-project/bpf-examples/pull/23) in mind, more specifically with those that are now in [PR#32](https://github.com/xdp-project/bpf-examples/pull/32). While the first two commits could potentially work without PR#32, the commit with more aggressive cleanup is based on the existance of ex. ICMP flows and "unopened" flows, and therefore makes little sense to merge before PR#32. I will therefore leave this as a draft for now.