### PR TITLE
AF_XDP-interaction: Implement TX-cyclic sending

### DIFF
--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -195,7 +195,7 @@ static uint64_t gettime(void)
 
 	res = clock_gettime(CLOCK_MONOTONIC, &t);
 	if (res < 0) {
-		fprintf(stderr, "Error with gettimeofday! (%i)\n", res);
+		fprintf(stderr, "Error with clock_gettime! (%i)\n", res);
 		exit(EXIT_FAIL);
 	}
 	return (uint64_t) t.tv_sec * NANOSEC_PER_SEC + t.tv_nsec;

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -868,8 +868,13 @@ static int tx_batch_pkts(struct xsk_socket_info *xsk,
 	}
 	xsk_ring_prod__submit(&xsk->tx, nr);
 
+	// Kick Tx
 	// sendto(xsk_socket__fd(xsk->xsk), NULL, 0, MSG_DONTWAIT, NULL, 0);
 	complete_tx(xsk);
+
+	// See if kicking Rx-side works
+	// recvfrom(xsk_socket__fd(xsk->xsk), NULL, 0, MSG_DONTWAIT, NULL, NULL);
+
 	return nr;
 }
 
@@ -1332,7 +1337,8 @@ int main(int argc, char **argv)
 	 * cost of copying over packet data to our preallocated AF_XDP umem
 	 * area.
 	 */
-	cfg.xsk_bind_flags = XDP_COPY;
+	// cfg.xsk_bind_flags = XDP_COPY;
+	cfg.xsk_bind_flags = XDP_COPY | XDP_USE_NEED_WAKEUP;
 
 	struct bpf_object *bpf_obj = NULL;
 	struct bpf_map *map;
@@ -1484,7 +1490,7 @@ int main(int argc, char **argv)
 	/* Receive and count packets than drop them */
 	// rx_and_process(&cfg, &xsks);
 
-
+	/* Send packets cyclic */
 	tx_cyclic_and_rx_process(&cfg, &xsks);
 
 	/* Cleanup */

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -1288,6 +1288,11 @@ int main(int argc, char **argv)
 			       cfg.sched_prio, cfg.sched_policy);
 	}
 
+	/* Issue: At this point AF_XDP socket might not be ready e.g. for TX.
+	 * It seems related with XDP attachment causing link down/up event for
+	 * some drivers.  Q: What is the right method/API that waits for link to
+	 * be initilized correctly?
+	 */
 	//sleep(3);
 	// tx_pkt(&cfg, xsks.sockets[0]);
 

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -806,6 +806,21 @@ static void rx_and_process(struct config *cfg,
 	}
 }
 
+/* Use-case: Accurate cyclic Tx and lazy RX-processing
+ *
+ * This processing loop is simulating a Time-Triggered schedule, where
+ * transmitting packets within a small time-window is the most
+ * important task.  Picking up frames in RX-queue is less time
+ * critical, as the PCF synchronization packets will have been
+ * timestamped (rx_ktime) by XDP before they got enqueued.
+ */
+static void tx_and_rx_batch_process(struct config *cfg,
+				    struct xsk_container *xsks)
+{
+
+
+}
+
 static double calc_period(struct stats_record *r, struct stats_record *p)
 {
 	double period_ = 0;

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -591,18 +591,9 @@ static void gen_udp_hdr(struct udphdr *udp_hdr, struct iphdr *ip_hdr)
 	udp_hdr->len = htons(UDP_PKT_SIZE);
 
 	/* UDP data */
-	memset32_htonl(udp_hdr + sizeof(struct udphdr),
+	memset32_htonl((void*)udp_hdr + sizeof(struct udphdr),
 		       opt_pkt_fill_pattern,
 		       UDP_PKT_DATA_SIZE);
-
-	if (0) {
-		uint8_t *p = udp_hdr + sizeof(struct udphdr);
-		int i;
-
-		for (i = 0; i < UDP_PKT_DATA_SIZE; i++) {
-			printf("i[%d] = %c\n", i, p[i]);
-		}
-	}
 
 	/* UDP header checksum */
 	udp_hdr->check = 0;

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -288,6 +288,9 @@ static const struct option_wrapper long_options[] = {
 	{{"progsec",	 required_argument,	NULL,  2  },
 	 "Load program in <section> of the ELF file", "<section>"},
 
+	{{"busy-poll",	 no_argument,		NULL, 'B' },
+	 "Enable socket prefer NAPI busy-poll mode (remember adjust sysctl too)"},
+
 	{{0, 0, NULL,  0 }, NULL, false}
 };
 
@@ -496,7 +499,7 @@ static struct xsk_socket_info *xsk_configure_socket(struct config *cfg,
 	/* Due to XSK_LIBBPF_FLAGS__INHIBIT_PROG_LOAD manually update map */
 	//  xsk_socket__update_xskmap(xsk_info->xsk, xsks_map_fd);
 
-	apply_setsockopt(xsk_info, true, RX_BATCH_SIZE);
+	apply_setsockopt(xsk_info, cfg->opt_busy_poll, RX_BATCH_SIZE);
 
 	return xsk_info;
 

--- a/AF_XDP-interaction/common_defines.h
+++ b/AF_XDP-interaction/common_defines.h
@@ -4,6 +4,7 @@
 #include <net/if.h>
 #include <linux/types.h>
 #include <stdbool.h>
+#include <netinet/ether.h> /* struct ether_addr */
 
 struct config {
 	__u32 xdp_flags;
@@ -27,6 +28,8 @@ struct config {
 	int sched_prio;
 	int sched_policy;
 	bool opt_busy_poll;
+	struct ether_addr opt_tx_smac;
+	struct ether_addr opt_tx_dmac;
 };
 
 /* Defined in common_params.o */

--- a/AF_XDP-interaction/common_defines.h
+++ b/AF_XDP-interaction/common_defines.h
@@ -26,6 +26,7 @@ struct config {
 	/* Real-Time scheduler setting */
 	int sched_prio;
 	int sched_policy;
+	bool opt_busy_poll;
 };
 
 /* Defined in common_params.o */

--- a/AF_XDP-interaction/common_params.c
+++ b/AF_XDP-interaction/common_params.c
@@ -96,7 +96,7 @@ void parse_cmdline_args(int argc, char **argv,
 	}
 
 	/* Parse commands line args */
-	while ((opt = getopt_long(argc, argv, "hd:r:L:R:ASNFUMQ:czqp:",
+	while ((opt = getopt_long(argc, argv, "hd:r:L:R:BASNFUMQ:czqp:",
 				  long_options, &longindex)) != -1) {
 		switch (opt) {
 		case 'd':
@@ -128,6 +128,9 @@ void parse_cmdline_args(int argc, char **argv,
 						errno, strerror(errno));
 				goto error;
 			}
+			break;
+		case 'B':
+			cfg->opt_busy_poll = true;
 			break;
 		case 'A':
 			cfg->xdp_flags &= ~XDP_FLAGS_MODES;    /* Clear flags */

--- a/AF_XDP-interaction/common_params.c
+++ b/AF_XDP-interaction/common_params.c
@@ -29,7 +29,7 @@ void _print_options(const struct option_wrapper *long_options, bool required)
 		if (long_options[i].required != required)
 			continue;
 
-		if (long_options[i].option.val > 64) /* ord('A') = 65 */
+		if (long_options[i].option.val > 64) /* ord('A') = 65 = 0x41 */
 			printf(" -%c,", long_options[i].option.val);
 		else
 			printf("    ");
@@ -96,7 +96,7 @@ void parse_cmdline_args(int argc, char **argv,
 	}
 
 	/* Parse commands line args */
-	while ((opt = getopt_long(argc, argv, "hd:r:L:R:BASNFUMQ:czqp:",
+	while ((opt = getopt_long(argc, argv, "hd:r:L:R:BASNFUMQ:G:H:czqp:",
 				  long_options, &longindex)) != -1) {
 		switch (opt) {
 		case 'd':
@@ -126,6 +126,22 @@ void parse_cmdline_args(int argc, char **argv,
 				fprintf(stderr,
 						"ERR: --redirect-dev name unknown err(%d):%s\n",
 						errno, strerror(errno));
+				goto error;
+			}
+			break;
+		case 'G':
+			if (!ether_aton_r(optarg,
+					  (struct ether_addr *)&cfg->opt_tx_dmac)) {
+				fprintf(stderr, "Invalid dest MAC address:%s\n",
+					optarg);
+				goto error;
+			}
+			break;
+		case 'H':
+			if (!ether_aton_r(optarg,
+					  (struct ether_addr *)&cfg->opt_tx_smac)) {
+				fprintf(stderr, "Invalid src MAC address:%s\n",
+					optarg);
 				goto error;
 			}
 			break;

--- a/AF_XDP-interaction/lib_checksum.h
+++ b/AF_XDP-interaction/lib_checksum.h
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0
+// Code taken from kernel samples/bpf/xdpsock_user.c
+
+#ifndef __LIB_CHECKSUM_H
+#define __LIB_CHECKSUM_H
+
+static void *memset32_htonl(void *dest, __u32 val, __u32 size)
+{
+	__u32 *ptr = (__u32 *)dest;
+	int i;
+
+	val = htonl(val);
+
+	for (i = 0; i < (size & (~0x3)); i += 4)
+		ptr[i >> 2] = val;
+
+	for (; i < size; i++)
+		((char *)dest)[i] = ((char *)&val)[i & 3];
+
+	return dest;
+}
+
+/*
+ * This function code has been taken from
+ * Linux kernel lib/checksum.c
+ */
+static inline unsigned short from32to16(unsigned int x)
+{
+	/* add up 16-bit and 16-bit for 16+c bit */
+	x = (x & 0xffff) + (x >> 16);
+	/* add up carry.. */
+	x = (x & 0xffff) + (x >> 16);
+	return x;
+}
+
+/*
+ * This function code has been taken from
+ * Linux kernel lib/checksum.c
+ */
+static unsigned int do_csum(const unsigned char *buff, int len)
+{
+	unsigned int result = 0;
+	int odd;
+
+	if (len <= 0)
+		goto out;
+	odd = 1 & (unsigned long)buff;
+	if (odd) {
+#ifdef __LITTLE_ENDIAN
+		result += (*buff << 8);
+#else
+		result = *buff;
+#endif
+		len--;
+		buff++;
+	}
+	if (len >= 2) {
+		if (2 & (unsigned long)buff) {
+			result += *(unsigned short *)buff;
+			len -= 2;
+			buff += 2;
+		}
+		if (len >= 4) {
+			const unsigned char *end = buff +
+						   ((unsigned int)len & ~3);
+			unsigned int carry = 0;
+
+			do {
+				unsigned int w = *(unsigned int *)buff;
+
+				buff += 4;
+				result += carry;
+				result += w;
+				carry = (w > result);
+			} while (buff < end);
+			result += carry;
+			result = (result & 0xffff) + (result >> 16);
+		}
+		if (len & 2) {
+			result += *(unsigned short *)buff;
+			buff += 2;
+		}
+	}
+	if (len & 1)
+#ifdef __LITTLE_ENDIAN
+		result += *buff;
+#else
+		result += (*buff << 8);
+#endif
+	result = from32to16(result);
+	if (odd)
+		result = ((result >> 8) & 0xff) | ((result & 0xff) << 8);
+out:
+	return result;
+}
+
+/*
+ *	This is a version of ip_compute_csum() optimized for IP headers,
+ *	which always checksum on 4 octet boundaries.
+ *	This function code has been taken from
+ *	Linux kernel lib/checksum.c
+ */
+static inline __sum16 ip_fast_csum(const void *iph, unsigned int ihl)
+{
+	return (__sum16)~do_csum(iph, ihl * 4);
+}
+
+/*
+ * Fold a partial checksum
+ * This function code has been taken from
+ * Linux kernel include/asm-generic/checksum.h
+ */
+static inline __sum16 csum_fold(__wsum csum)
+{
+	__u32 sum = (__u32)csum;
+
+	sum = (sum & 0xffff) + (sum >> 16);
+	sum = (sum & 0xffff) + (sum >> 16);
+	return (__sum16)~sum;
+}
+
+/*
+ * This function code has been taken from
+ * Linux kernel lib/checksum.c
+ */
+static inline __u32 from64to32(__u64 x)
+{
+	/* add up 32-bit and 32-bit for 32+c bit */
+	x = (x & 0xffffffff) + (x >> 32);
+	/* add up carry.. */
+	x = (x & 0xffffffff) + (x >> 32);
+	return (__u32)x;
+}
+
+__wsum csum_tcpudp_nofold(__be32 saddr, __be32 daddr,
+			  __u32 len, __u8 proto, __wsum sum);
+
+/*
+ * This function code has been taken from
+ * Linux kernel lib/checksum.c
+ */
+__wsum csum_tcpudp_nofold(__be32 saddr, __be32 daddr,
+			  __u32 len, __u8 proto, __wsum sum)
+{
+	unsigned long long s = (__u32)sum;
+
+	s += (__u32)saddr;
+	s += (__u32)daddr;
+#ifdef __BIG_ENDIAN__
+	s += proto + len;
+#else
+	s += (proto + len) << 8;
+#endif
+	return (__wsum)from64to32(s);
+}
+
+/*
+ * This function has been taken from
+ * Linux kernel include/asm-generic/checksum.h
+ */
+static inline __sum16
+csum_tcpudp_magic(__be32 saddr, __be32 daddr, __u32 len,
+		  __u8 proto, __wsum sum)
+{
+	return csum_fold(csum_tcpudp_nofold(saddr, daddr, len, proto, sum));
+}
+
+static inline __u16 udp_csum(__u32 saddr, __u32 daddr, __u32 len,
+			   __u8 proto, __u16 *udp_pkt)
+{
+	__u32 csum = 0;
+	__u32 cnt = 0;
+
+	/* udp hdr and data */
+	for (; cnt < len; cnt += 2)
+		csum += udp_pkt[cnt >> 1];
+
+	return csum_tcpudp_magic(saddr, daddr, len, proto, csum);
+}
+
+#endif /* __LIB_CHECKSUM_H */


### PR DESCRIPTION
The main customer use-case for the AF_XDP example is actually accurately periodic transmits, for matching a Time-Triggered Ethernet schedule.

In this PR we don't handle the time-sync or schedule, we only demonstrate periodic TX-cyclic sending.
