### PR TITLE
AF_XDP example: Improvements to wake-up accuracy

### DIFF
--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -279,6 +279,9 @@ static const struct option_wrapper long_options[] = {
 	{{"metainfo",	 no_argument,		NULL, 'm' },
 	 "Print XDP metadata info output mode (debug)"},
 
+	{{"timedebug",	 no_argument,		NULL, 't' },
+	 "Print timestamps info for wakeup accuracy (debug)"},
+
 	{{"debug",	 no_argument,		NULL, 'D' },
 	 "Debug info output mode (debug)"},
 
@@ -1289,9 +1292,11 @@ static void tx_cyclic_and_rx_process(struct config *cfg,
 			       stat.curr - stat.prev,
 			       diff_interval);
 
-		print_timespec(&now,  "now");
-		print_timespec(&next_adj, "next_adj");
-		print_timespec(&next, "next");
+		if (debug_time) {
+			print_timespec(&now,  "now");
+			print_timespec(&next_adj, "next_adj");
+			print_timespec(&next, "next");
+		}
 
 		/* Calculate next time to wakeup */
 		next.tv_sec  += interval.tv_sec;

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -1234,6 +1234,7 @@ static void tx_cyclic_and_rx_process(struct config *cfg,
 	struct xdp_desc tx_pkts[BATCH_PKTS_MAX];
 	int batch_nr = cfg->batch_pkts;
 	int tx_nr;
+	bool first = true;
 
 	int period = cfg->interval;
 	int timermode = TIMER_ABSTIME;
@@ -1283,10 +1284,14 @@ static void tx_cyclic_and_rx_process(struct config *cfg,
 
 		/* How close is wakeup time to our actual target */
 		diff = calcdiff_ns(now, next); /* Positive num = wokeup after */
-		if (diff < stat.min)
-			stat.min = diff;
-		if (diff > stat.max)
-			stat.max = diff;
+		/* Exclude first measurement as no next_adj happened */
+		if (!first) {
+			if (diff < stat.min)
+				stat.min = diff;
+			if (diff > stat.max)
+				stat.max = diff;
+		}
+		first = false;
 		stat.avg += (double) diff;
 		stat.prev = stat.curr;
 		stat.curr = diff;

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -303,6 +303,9 @@ static const struct option_wrapper long_options[] = {
 	{{"interval",	 required_argument,	NULL, 'i' },
 	 "Periodic TX-cyclic interval wakeup period in usec", "<usec>"},
 
+	{{"batch-pkts",	 required_argument,	NULL, 'b' },
+	 "Periodic TX-cyclic batch send pkts", "<pkts>"},
+
 	{{0, 0, NULL,  0 }, NULL, false}
 };
 
@@ -1237,8 +1240,8 @@ static void tx_cyclic_and_rx_process(struct config *cfg,
 	struct timespec now, next, next_adj, interval, now_prev;
 	struct wakeup_stat stat = { .min = DEFAULT_INTERVAL, .max = -0xFFFF };
 	struct wakeup_stat stat_adj = { .min = DEFAULT_INTERVAL, .max = -0xFFFF };
-	int batch_nr = 4;
-	struct xdp_desc tx_pkts[batch_nr];
+	struct xdp_desc tx_pkts[BATCH_PKTS_MAX];
+	int batch_nr = cfg->batch_pkts;
 	int tx_nr;
 
 	int period = cfg->interval;
@@ -1475,6 +1478,7 @@ int main(int argc, char **argv)
 		.opt_tx_dmac = default_tx_dmac,
 		.opt_tx_smac = default_tx_smac,
 		.interval = DEFAULT_INTERVAL,
+		.batch_pkts = BATCH_PKTS_DEFAULT,
 	};
 	pthread_t stats_poll_thread;
 	struct xsk_umem_info *umem;

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -1224,7 +1224,8 @@ static void tx_cyclic_and_rx_process(struct config *cfg,
 
 	next = now;
 	next.tv_sec  += interval.tv_sec;
-	next.tv_nsec += interval.tv_nsec;
+	// next.tv_nsec += interval.tv_nsec;
+	next.tv_nsec = 0;
 	tsnorm(&next);
 	next_adj = next; /* Not adjusted yet */
 

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -1148,6 +1148,17 @@ static inline void tsnorm(struct timespec *ts)
 	}
 }
 
+static inline uint64_t timespec2ns(struct timespec *ts)
+{
+	return (uint64_t) ts->tv_sec * NANOSEC_PER_SEC + ts->tv_nsec;
+}
+
+static inline void ns2timespec(uint64_t ns, struct timespec *ts)
+{
+	ts->tv_sec  = ns / NANOSEC_PER_SEC;
+	ts->tv_nsec = ns % NANOSEC_PER_SEC;
+}
+
 static inline int64_t calcdiff(struct timespec t1, struct timespec t2)
 {
 	int64_t diff;
@@ -1287,8 +1298,9 @@ static void tx_cyclic_and_rx_process(struct config *cfg,
 		tsnorm(&next);
 
 		/* Adjust for inaccuracy of clock_nanosleep wakeup */
-		next_adj = next;
-		next_adj.tv_nsec = next_adj.tv_nsec - avg2adj;
+		uint64_t next_adj_ns = timespec2ns(&next);
+		next_adj_ns = next_adj_ns - avg2adj;
+		ns2timespec(next_adj_ns, &next_adj);
 		tsnorm(&next_adj);
 
 		/* Get packets for *next* iteration */

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -653,7 +653,7 @@ static bool get_ipv4_u32(char *ip_str, uint32_t *ip_addr)
 	return true;
 }
 
-static char *opt_ip_str_src = "192.168.44.2";
+static char *opt_ip_str_src = "192.168.44.1";
 static char *opt_ip_str_dst = "192.168.44.3";
 
 static void gen_ip_hdr(struct iphdr *ip_hdr)

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -300,6 +300,9 @@ static const struct option_wrapper long_options[] = {
 	{{"tx-smac",	 required_argument,	NULL, 'H' },
 	 "Src MAC addr of TX frame in aa:bb:cc:dd:ee:ff format", "aa:bb:cc:dd:ee:ff"},
 
+	{{"interval",	 required_argument,	NULL, 'i' },
+	 "Periodic TX-cyclic interval wakeup period in usec", "<usec>"},
+
 	{{0, 0, NULL,  0 }, NULL, false}
 };
 
@@ -1138,7 +1141,7 @@ static void rx_avail_packets(struct xsk_container *xsks)
 }
 
 /* Default interval in usec */
-#define DEFAULT_INTERVAL 1000000
+#define DEFAULT_INTERVAL	1000000
 
 #define USEC_PER_SEC		1000000
 #define NSEC_PER_SEC		1000000000
@@ -1210,7 +1213,7 @@ static void tx_cyclic_and_rx_process(struct config *cfg,
 	struct xdp_desc tx_pkts[batch_nr];
 	int tx_nr;
 
-	int period = DEFAULT_INTERVAL; // TODO: Add to cfg
+	int period = cfg->interval;
 	int timermode = TIMER_ABSTIME;
 	int clock = CLOCK_MONOTONIC;
 
@@ -1286,7 +1289,7 @@ static void tx_cyclic_and_rx_process(struct config *cfg,
 			printf("TX pkts:%d event:%lu"
 			       " inaccurate wakeup(nanosec) curr:%ld"
 			       "(min:%ld max:%ld avg:%ld avg2adj:%ld)"
-			       " variance(n-1):%ld interval:%ld\n",
+			       " variance(n-1):%ld interval-ns:%ld\n",
 			       n, stat.events, stat.curr,
 			       stat.min, stat.max, avg, avg2adj,
 			       stat.curr - stat.prev,
@@ -1444,6 +1447,7 @@ int main(int argc, char **argv)
 		.xsk_if_queue = -1,
 		.opt_tx_dmac = default_tx_dmac,
 		.opt_tx_smac = default_tx_smac,
+		.interval = DEFAULT_INTERVAL,
 	};
 	pthread_t stats_poll_thread;
 	struct xsk_umem_info *umem;

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -857,6 +857,8 @@ static void tx_pkt(struct config *cfg, struct xsk_socket_info *xsk)
 		if (ret != 1) {
 			/* No more transmit slots, drop the packet */
 			mem_free_umem_frame(&umem->mem, pkt_addr);
+			fprintf(stderr, "ERR - %s() failed transmit\n",
+				__func__);
 		}
 
 		xsk_ring_prod__tx_desc(&xsk->tx, tx_idx)->addr = pkt_addr;
@@ -1555,7 +1557,7 @@ int main(int argc, char **argv)
 	 * be initilized correctly?
 	 */
 	//sleep(3);
-	// tx_pkt(&cfg, xsks.sockets[0]);
+	tx_pkt(&cfg, xsks.sockets[0]);
 
 	/* Receive and count packets than drop them */
 	// rx_and_process(&cfg, &xsks);

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -568,6 +568,12 @@ static void complete_tx(struct xsk_socket_info *xsk)
 		}
 
 		xsk_ring_cons__release(&xsk->cq, completed);
+		if (completed > xsk->outstanding_tx) {
+			fprintf(stderr, "WARN: %s() "
+				"reset outstanding_tx(%d) as completed(%d)"
+				"more than outstanding TX pakcets\n",
+				__func__, xsk->outstanding_tx, completed);
+		}
 		xsk->outstanding_tx -= completed < xsk->outstanding_tx ?
 			completed : xsk->outstanding_tx;
 	}

--- a/AF_XDP-interaction/af_xdp_user.c
+++ b/AF_XDP-interaction/af_xdp_user.c
@@ -1230,8 +1230,7 @@ static void tx_cyclic_and_rx_process(struct config *cfg,
 
 	next = now;
 	next.tv_sec  += interval.tv_sec;
-	// next.tv_nsec += interval.tv_nsec;
-	next.tv_nsec = 0;
+	next.tv_nsec += interval.tv_nsec;
 	tsnorm(&next);
 	next_adj = next; /* Not adjusted yet */
 

--- a/AF_XDP-interaction/common_defines.h
+++ b/AF_XDP-interaction/common_defines.h
@@ -30,6 +30,7 @@ struct config {
 	bool opt_busy_poll;
 	struct ether_addr opt_tx_smac;
 	struct ether_addr opt_tx_dmac;
+	__u64 interval;
 };
 
 /* Defined in common_params.o */

--- a/AF_XDP-interaction/common_defines.h
+++ b/AF_XDP-interaction/common_defines.h
@@ -37,6 +37,7 @@ extern int verbose;
 extern int debug;
 extern int debug_pkt;
 extern int debug_meta;
+extern int debug_time;
 
 /* Exit return codes */
 #define EXIT_OK 		 0 /* == EXIT_SUCCESS (stdlib.h) man exit(3) */

--- a/AF_XDP-interaction/common_defines.h
+++ b/AF_XDP-interaction/common_defines.h
@@ -32,6 +32,8 @@ struct config {
 	struct ether_addr opt_tx_dmac;
 	__u64 interval;
 	__u32 batch_pkts;
+	__u32 opt_ip_src;
+	__u32 opt_ip_dst;
 };
 
 #define BATCH_PKTS_MAX		64

--- a/AF_XDP-interaction/common_defines.h
+++ b/AF_XDP-interaction/common_defines.h
@@ -31,7 +31,11 @@ struct config {
 	struct ether_addr opt_tx_smac;
 	struct ether_addr opt_tx_dmac;
 	__u64 interval;
+	__u32 batch_pkts;
 };
+
+#define BATCH_PKTS_MAX		64
+#define BATCH_PKTS_DEFAULT	4
 
 /* Defined in common_params.o */
 extern int verbose;

--- a/AF_XDP-interaction/common_params.c
+++ b/AF_XDP-interaction/common_params.c
@@ -97,7 +97,8 @@ void parse_cmdline_args(int argc, char **argv,
 	}
 
 	/* Parse commands line args */
-	while ((opt = getopt_long(argc, argv, "hd:r:L:R:BASNFUMQ:G:H:czqp:ti:",
+	while ((opt = getopt_long(argc, argv,
+				  "hd:r:L:R:BASNFUMQ:G:H:czqp:ti:b:",
 				  long_options, &longindex)) != -1) {
 		switch (opt) {
 		case 'd':
@@ -143,6 +144,15 @@ void parse_cmdline_args(int argc, char **argv,
 					  (struct ether_addr *)&cfg->opt_tx_smac)) {
 				fprintf(stderr, "Invalid src MAC address:%s\n",
 					optarg);
+				goto error;
+			}
+			break;
+		case 'b':
+			cfg->batch_pkts = atoi(optarg);
+			if (cfg->batch_pkts > BATCH_PKTS_MAX) {
+				fprintf(stderr, "ERROR: "
+					" batch (%u) pkts limited to %u\n",
+					cfg->batch_pkts, BATCH_PKTS_MAX);
 				goto error;
 			}
 			break;

--- a/AF_XDP-interaction/common_params.c
+++ b/AF_XDP-interaction/common_params.c
@@ -17,6 +17,7 @@ int verbose = 1;
 int debug = 0;
 int debug_pkt = 0;
 int debug_meta = 0;
+int debug_time = 0;
 
 #define BUFSIZE 30
 
@@ -96,7 +97,7 @@ void parse_cmdline_args(int argc, char **argv,
 	}
 
 	/* Parse commands line args */
-	while ((opt = getopt_long(argc, argv, "hd:r:L:R:BASNFUMQ:G:H:czqp:",
+	while ((opt = getopt_long(argc, argv, "hd:r:L:R:BASNFUMQ:G:H:czqp:t",
 				  long_options, &longindex)) != -1) {
 		switch (opt) {
 		case 'd':
@@ -195,6 +196,9 @@ void parse_cmdline_args(int argc, char **argv,
 			break;
 		case 'm':
 			debug_meta = true;
+			break;
+		case 't':
+			debug_time = true;
 			break;
 		case 'Q':
 			cfg->xsk_if_queue = atoi(optarg);

--- a/AF_XDP-interaction/common_params.c
+++ b/AF_XDP-interaction/common_params.c
@@ -97,7 +97,7 @@ void parse_cmdline_args(int argc, char **argv,
 	}
 
 	/* Parse commands line args */
-	while ((opt = getopt_long(argc, argv, "hd:r:L:R:BASNFUMQ:G:H:czqp:t",
+	while ((opt = getopt_long(argc, argv, "hd:r:L:R:BASNFUMQ:G:H:czqp:ti:",
 				  long_options, &longindex)) != -1) {
 		switch (opt) {
 		case 'd':
@@ -218,6 +218,9 @@ void parse_cmdline_args(int argc, char **argv,
 		case 'R': /* --dest-mac */
 			dest  = (char *)&cfg->dest_mac;
 			strncpy(dest, optarg, sizeof(cfg->dest_mac));
+			break;
+		case 'i':
+			cfg->interval = atoi(optarg);
 			break;
 		case 'c':
 			cfg->xsk_bind_flags &= ~XDP_ZEROCOPY;	/* Clear flag */

--- a/AF_XDP-interaction/common_params.h
+++ b/AF_XDP-interaction/common_params.h
@@ -19,4 +19,6 @@ void parse_cmdline_args(int argc, char **argv,
 			const struct option_wrapper *long_options,
                         struct config *cfg, const char *doc);
 
+bool get_ipv4_u32(char *ip_str, uint32_t *ip_addr);
+
 #endif /* __COMMON_PARAMS_H */


### PR DESCRIPTION
Measurements show that on test systems, clock_nanosleep fairly consistently wakeup later (or after) the requested sleep time.

In this branch I've been playing with improving on wake-up accuracy for cyclic-TX.

Mainly creating this for @jopbs to notice ;-)