### PR TITLE
pping: Add graceful shutdown on SIGTERM

### DIFF
--- a/pping/pping.c
+++ b/pping/pping.c
@@ -1024,6 +1024,7 @@ int main(int argc, char *argv[])
 
 	// Allow program to perform cleanup on Ctrl-C
 	signal(SIGINT, abort_program);
+	signal(SIGTERM, abort_program);
 
 	// Main loop
 	while (keep_running) {


### PR DESCRIPTION
PPing previously only shut down gracefully on SIGINT, but did not handle SIGTERM which is the most common signal for killing a process non-interactively. Here I address that by simply adding the same signal-handler for the SIGTERM signal.

It may be worth considering if there are additional signals that should also be handled similarly, ex SIGHUP or SIGQUIT.

While not directly related, while I still remeber it @tohojo also suggested detecting if pping was already running on the interface, and then handle that. Is the correct way to do that to check for BPF-programs with the same name already attached to the interface and if found simply abort and inform the user that pping is already running?