### PR TITLE
PPing optimization: Tracking outstanding timestamps

### DIFF
--- a/pping/TODO.md
+++ b/pping/TODO.md
@@ -66,6 +66,9 @@
     - Keeping entries around for a long time allows the map to grow
     unnecessarily large, which slows down the cleaning and may block
     new entries
+- [x] Keep track of outstanding timestamps, only match when necessary
+  - Can avoid doing lookups in timestamp hash map if we know that
+  there are no outstanding (unmatched) timestamps for the flow
 
 
 # Potential issues

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -94,9 +94,10 @@ struct flow_state {
 	__u64 rec_pkts;
 	__u64 rec_bytes;
 	__u32 last_id;
+	__u32 outstanding_timestamps;
 	bool has_opened;
 	enum flow_event_reason opening_reason;
-	__u16 reserved;
+	__u8 reserved[6];
 };
 
 struct packet_id {


### PR DESCRIPTION
An attempt to improve the performance of ePPing by avoiding unnecessary lookups in the timestamp map. Instead of looking for matching timestamp for every (valid) packet, only look for matches in case we know there are unmatched timestamps for the flow.

I think it already works, but may still need some cleanup or other fixes before this is ready to be merged.