### PR TITLE
PPing dualdirection flowstate

### DIFF
--- a/pping/pping.c
+++ b/pping/pping.c
@@ -647,6 +647,8 @@ static const char *flowevent_to_str(enum flow_event_type fe)
 static const char *eventreason_to_str(enum flow_event_reason er)
 {
 	switch (er) {
+	case EVENT_REASON_NONE:
+		return "none";
 	case EVENT_REASON_SYN:
 		return "SYN";
 	case EVENT_REASON_SYN_ACK:

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -143,7 +143,7 @@ static const char *get_libbpf_strerror(int err)
 }
 
 static int parse_bounded_double(double *res, const char *str, double low,
-				   double high, const char *name)
+				double high, const char *name)
 {
 	char *endptr;
 	*res = strtod(str, &endptr);
@@ -170,8 +170,8 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 	config->bpf_config.track_tcp = false;
 	config->bpf_config.track_icmp = false;
 
-	while ((opt = getopt_long(argc, argv, "hflTCi:r:R:t:c:F:I:", long_options,
-				  NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hflTCi:r:R:t:c:F:I:",
+				  long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'i':
 			if (strlen(optarg) > IF_NAMESIZE) {
@@ -185,7 +185,8 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 				err = -errno;
 				fprintf(stderr,
 					"Could not get index of interface %s: %s\n",
-					config->ifname, get_libbpf_strerror(err));
+					config->ifname,
+					get_libbpf_strerror(err));
 				return err;
 			}
 			break;
@@ -210,8 +211,7 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 		case 't':
 			if (strcmp(optarg, "min") == 0) {
 				config->bpf_config.use_srtt = false;
-			}
-			else if (strcmp(optarg, "smoothed") == 0) {
+			} else if (strcmp(optarg, "smoothed") == 0) {
 				config->bpf_config.use_srtt = true;
 			} else {
 				fprintf(stderr,
@@ -237,7 +237,8 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 			} else if (strcmp(optarg, "ppviz") == 0) {
 				config->output_format = PPING_OUTPUT_PPVIZ;
 			} else {
-				fprintf(stderr, "format must be \"standard\", \"json\" or \"ppviz\"\n");
+				fprintf(stderr,
+					"format must be \"standard\", \"json\" or \"ppviz\"\n");
 				return -EINVAL;
 			}
 			break;
@@ -247,7 +248,8 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 			} else if (strcmp(optarg, "tc") == 0) {
 				config->ingress_prog = "pping_tc_ingress";
 			} else {
-				fprintf(stderr, "ingress-hook must be \"xdp\" or \"tc\"\n");
+				fprintf(stderr,
+					"ingress-hook must be \"xdp\" or \"tc\"\n");
 				return -EINVAL;
 			}
 			break;
@@ -293,10 +295,14 @@ const char *tracked_protocols_to_str(struct pping_config *config)
 const char *output_format_to_str(enum PPING_OUTPUT_FORMAT format)
 {
 	switch (format) {
-	case PPING_OUTPUT_STANDARD: return "standard";
-	case PPING_OUTPUT_JSON: return "json";
-	case PPING_OUTPUT_PPVIZ: return "ppviz";
-	default: return "unkown format";
+	case PPING_OUTPUT_STANDARD:
+		return "standard";
+	case PPING_OUTPUT_JSON:
+		return "json";
+	case PPING_OUTPUT_PPVIZ:
+		return "ppviz";
+	default:
+		return "unkown format";
 	}
 }
 
@@ -599,8 +605,8 @@ static int format_ip_address(char *buf, size_t size, int af,
 			     const struct in6_addr *addr)
 {
 	if (af == AF_INET)
-		return inet_ntop(af, &addr->s6_addr[12],
-				 buf, size) ? -errno : 0;
+		return inet_ntop(af, &addr->s6_addr[12], buf, size) ? -errno :
+									    0;
 	else if (af == AF_INET6)
 		return inet_ntop(af, addr, buf, size) ? -errno : 0;
 	return -EINVAL;
@@ -672,7 +678,8 @@ static const char *eventsource_to_str(enum flow_event_source es)
 	}
 }
 
-static void print_flow_ppvizformat(FILE *stream, const struct network_tuple *flow)
+static void print_flow_ppvizformat(FILE *stream,
+				   const struct network_tuple *flow)
 {
 	char saddr[INET6_ADDRSTRLEN];
 	char daddr[INET6_ADDRSTRLEN];
@@ -727,7 +734,8 @@ static void print_event_ppviz(const union pping_event *e)
 
 	printf("%llu.%09llu %llu.%09llu %llu.%09llu ", time / NS_PER_SECOND,
 	       time % NS_PER_SECOND, re->rtt / NS_PER_SECOND,
-	       re->rtt % NS_PER_SECOND, re->min_rtt / NS_PER_SECOND, re->min_rtt);
+	       re->rtt % NS_PER_SECOND, re->min_rtt / NS_PER_SECOND,
+	       re->min_rtt);
 	print_flow_ppvizformat(stdout, &re->flow);
 	printf("\n");
 }
@@ -768,8 +776,7 @@ static void print_flowevent_fields_json(json_writer_t *ctx,
 {
 	jsonw_string_field(ctx, "flow_event",
 			   flowevent_to_str(fe->flow_event_type));
-	jsonw_string_field(ctx, "reason",
-			   eventreason_to_str(fe->reason));
+	jsonw_string_field(ctx, "reason", eventreason_to_str(fe->reason));
 	jsonw_string_field(ctx, "triggered_by", eventsource_to_str(fe->source));
 }
 

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -50,6 +50,13 @@ enum __attribute__((__packed__)) pping_map {
 	PPING_MAP_PACKETTS
 };
 
+enum __attribute__((__packed__)) connection_state {
+        CONNECTION_STATE_EMPTY,
+        CONNECTION_STATE_WAITOPEN,
+        CONNECTION_STATE_OPEN,
+        CONNECTION_STATE_CLOSED
+};
+
 struct bpf_config {
 	__u64 rate_limit;
 	fixpoint64 rtt_rate;
@@ -96,11 +103,9 @@ struct flow_state {
 	__u64 rec_bytes;
 	__u32 last_id;
 	__u32 outstanding_timestamps;
-	bool has_opened;
+	enum connection_state conn_state;
 	enum flow_event_reason opening_reason;
-	bool is_empty;
-	bool has_closed;
-	__u32 reserved;
+	__u8 reserved[6];
 };
 
 /*

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -30,6 +30,7 @@ enum __attribute__((__packed__)) flow_event_type {
 };
 
 enum __attribute__((__packed__)) flow_event_reason {
+	EVENT_REASON_NONE,
 	EVENT_REASON_SYN,
 	EVENT_REASON_SYN_ACK,
 	EVENT_REASON_FIRST_OBS_PCKT,

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -98,7 +98,20 @@ struct flow_state {
 	__u32 outstanding_timestamps;
 	bool has_opened;
 	enum flow_event_reason opening_reason;
-	__u8 reserved[6];
+	bool is_empty;
+	bool has_closed;
+	__u32 reserved;
+};
+
+/*
+ * Stores flowstate for both direction (src -> dst and dst -> src) of a flow
+ *
+ * Uses two named members instead of array of size 2 to avoid hassels with
+ * convincing verifier that member access is not out of bounds
+ */
+struct dual_flow_state {
+	struct flow_state dir1;
+	struct flow_state dir2;
 };
 
 struct packet_id {

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -9,7 +9,7 @@
 #define NS_PER_SECOND 1000000000UL
 #define NS_PER_MS 1000000UL
 #define MS_PER_S 1000UL
-#define S_PER_DAY (24*3600UL)
+#define S_PER_DAY (24 * 3600UL)
 
 typedef __u64 fixpoint64;
 #define FIXPOINT_SHIFT 16

--- a/pping/pping_kern.c
+++ b/pping/pping_kern.c
@@ -265,7 +265,7 @@ static int parse_tcp_identifier(struct parsing_context *pctx,
 	} else if (p_info->tcph->syn) {
 		p_info->event_type = FLOW_EVENT_OPENING;
 		p_info->event_reason = p_info->tcph->ack ?
-						     EVENT_REASON_SYN_ACK :
+					       EVENT_REASON_SYN_ACK :
 						     EVENT_REASON_SYN;
 	} else {
 		p_info->event_type = FLOW_EVENT_NONE;
@@ -521,8 +521,8 @@ static struct flow_state *create_flow(void *ctx, struct packet_info *p_info)
 
 	new_state.last_timestamp = p_info->time;
 	new_state.opening_reason = p_info->event_type == FLOW_EVENT_OPENING ?
-					       p_info->event_reason :
-					       EVENT_REASON_FIRST_OBS_PCKT;
+					   p_info->event_reason :
+						 EVENT_REASON_FIRST_OBS_PCKT;
 
 	if (bpf_map_update_elem(&flow_state, &p_info->pid.flow, &new_state,
 				BPF_NOEXIST) != 0) {
@@ -745,10 +745,10 @@ static void pping_match_packet(struct flow_state *f_state, void *ctx,
 static void pping(void *ctx, struct parsing_context *pctx)
 {
 	struct packet_info p_info = { 0 };
-	struct flow_state *flow, *rev_flow;;
+	struct flow_state *flow, *rev_flow;
 	bool new_flow;
 
- 	if (parse_packet_identifier(pctx, &p_info) < 0)
+	if (parse_packet_identifier(pctx, &p_info) < 0)
 		return;
 
 	flow = update_flow(ctx, &p_info, &new_flow);
@@ -758,7 +758,6 @@ static void pping(void *ctx, struct parsing_context *pctx)
 	pping_match_packet(rev_flow, ctx, pctx, &p_info);
 
 	delete_closed_flows(ctx, &p_info, flow, rev_flow);
-
 }
 
 // Programs


### PR DESCRIPTION
Attempt at optimizing ePPing by only doing a single map lookup to get flow state for both directions of the flow (down from two lookups, one for each direction). This is accomplished by placing the flow state from both directions into a single map entry, and using a common key (in this case created by sorting the flow tuple) for lookup.

The first two commits are just minor refactors. I guess they're not really related to this PR, so could break it out into a separate PR if requested. 

The third commit contains the change merging the flow state for both directions into a single map entry. This has some implications of how flow states are created, deleted and looked up, which affects both the ingress/egress programs as well as the periodical cleanup programs. Therefore, this commit contains quite extensive changes.

The fourth commit get's rid of a combination of boolean flags for keeping track of the flow's connection state, and replaces them with a single enum instead. While this could potentially be squashed into the 3rd commit (as the 3rd commit introduces the additional boolean flags), I figured the 3rd commit was already pretty large so did that in a separate commit.

I would also like to refactor the functions for sending flow events a bit (the 3rd commit introduces an additional one) as they have quite a lot of repeated code, but guess that's not directly related to this PR so should maybe wait with that.