### PR TITLE
BTF playground for extracting Kernel BTF object ID

### DIFF
--- a/BTF-playground/Makefile
+++ b/BTF-playground/Makefile
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 
 USER_TARGETS := btf_module_read
+USER_TARGETS += btf_module_ids
 #BPF_TARGETS  := ktrace01_kern
 
 LIB_DIR = ../lib

--- a/BTF-playground/btf_module_ids.c
+++ b/BTF-playground/btf_module_ids.c
@@ -118,7 +118,6 @@ int __btf_obj_info_via_fd(int fd, struct bpf_btf_info *info)
 #undef SZ
 }
 
-
 struct btf *open_vmlinux_btf(void)
 {
 	struct btf* btf_obj;
@@ -127,6 +126,11 @@ struct btf *open_vmlinux_btf(void)
 	//btf_obj = btf_load_vmlinux_from_kernel();
 	btf_obj = btf__load_vmlinux_btf();
 
+	/* *** DOES NOT WORK ***
+	 *
+	 * The struct btf object returned by btf__load_vmlinux_btf() doesn't
+	 * have a file descriptor set we can use.
+	 */
 	fd = btf__fd(btf_obj);
 	if (fd < 0)
 		pr_err("WARN: BTF-obj miss FD(%d)\n", fd);
@@ -255,7 +259,7 @@ static const char *module_name = "tun";
 
 int main(int argc, char **argv)
 {
-	struct btf *vmlinux_btf;
+//	struct btf *vmlinux_btf;
 	int opt, longindex = 0;
 	int module_btf_id;
 	int module_btf_sz;
@@ -276,7 +280,7 @@ int main(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 
-        vmlinux_btf = open_vmlinux_btf();
+//	vmlinux_btf = open_vmlinux_btf();
 
 //	err = walk_all_ids();
 
@@ -289,7 +293,7 @@ int main(int argc, char **argv)
 		       module_btf_id, module_name);
 	}
 
-	btf__free(vmlinux_btf);
+//	btf__free(vmlinux_btf);
 	if (err)
 		return EXIT_FAILURE;
 	return EXIT_SUCCESS;

--- a/BTF-playground/btf_module_ids.c
+++ b/BTF-playground/btf_module_ids.c
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0+
+
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include <bpf/btf.h> /* Notice libbpf BTF include */
+
+#include <linux/err.h>
+
+static const struct option long_options[] = {
+	{ "debug",	no_argument,	NULL,	'd' },
+	{ 0, 0, NULL, 0 }
+};
+
+int print_all_levels(enum libbpf_print_level level,
+		     const char *format, va_list args)
+{
+	return vfprintf(stderr, format, args);
+}
+
+#define pr_err(fmt, ...) \
+	fprintf(stderr, "%s:%d - " fmt, __FILE__, __LINE__, ##__VA_ARGS__)
+
+int main(int argc, char **argv)
+{
+	int opt, longindex = 0;
+        int err = 0;
+
+	/* Parse commands line args */
+	while ((opt = getopt_long(argc, argv, "d",
+				  long_options, &longindex)) != -1) {
+		switch (opt) {
+		case 'd':
+			libbpf_set_print(print_all_levels);
+			break;
+		default:
+			pr_err("Unrecognized option '%s'\n", argv[optind - 1]);
+			return EXIT_FAILURE;
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if (err)
+		return EXIT_FAILURE;
+	return EXIT_SUCCESS;
+}

--- a/BTF-playground/btf_module_ids.c
+++ b/BTF-playground/btf_module_ids.c
@@ -15,9 +15,12 @@
 #include <linux/err.h>
 
 static const struct option long_options[] = {
-	{ "debug",	no_argument,	NULL,	'd' },
+	{ "debug",		no_argument,		NULL,	'd' },
+	{ "module-name",	required_argument,	NULL,	'm' },
 	{ 0, 0, NULL, 0 }
 };
+
+static char module_name[128] = "tun"; /* Default module to lookup */
 
 int print_all_levels(enum libbpf_print_level level,
 		     const char *format, va_list args)
@@ -255,8 +258,6 @@ int find_btf_id_by_name(const char *btf_name, int *btf_size)
 }
 
 
-static const char *module_name = "tun";
-
 int main(int argc, char **argv)
 {
 //	struct btf *vmlinux_btf;
@@ -265,12 +266,16 @@ int main(int argc, char **argv)
 	int module_btf_sz;
         int err = 0;
 
+
 	/* Parse commands line args */
-	while ((opt = getopt_long(argc, argv, "d",
+	while ((opt = getopt_long(argc, argv, "dm:",
 				  long_options, &longindex)) != -1) {
 		switch (opt) {
 		case 'd':
 			libbpf_set_print(print_all_levels);
+			break;
+		case 'm': /* --module */
+			strncpy(module_name, optarg, sizeof(module_name) - 1);
 			break;
 		default:
 			pr_err("Unrecognized option '%s'\n", argv[optind - 1]);

--- a/BTF-playground/btf_module_read.c
+++ b/BTF-playground/btf_module_read.c
@@ -72,6 +72,22 @@ int fail1_get_kernel_btf_obj_id(struct btf *btf_obj)
 	return __btf_obj_id_via_fd(btf_fd);
 }
 
+int fail2_get_kernel_btf_obj_id(const char *module_name)
+{
+	/* *** DOES NOT WORK ***/
+	char path[512] = {};
+	int fd;
+
+	snprintf(path, sizeof(path), "/sys/kernel/btf/%s", module_name);
+	fd = open(path, O_RDONLY | O_CLOEXEC);
+	if (fd < 0) {
+		pr_err("ERR: Cannot open BTF file %s (FD:%d)\n", path, fd);
+		return 0;
+	}
+
+	return __btf_obj_id_via_fd(fd);
+}
+
 int main(int argc, char **argv)
 {
 	struct btf *vmlinux_btf, *module_btf = NULL;
@@ -121,6 +137,8 @@ int main(int argc, char **argv)
 	/* Wanted to get BTF object ID used by kernel that ident BTF */
 	//btf_obj_id = fail1_get_kernel_btf_obj_id(vmlinux_btf);
 	btf_obj_id = fail1_get_kernel_btf_obj_id(module_btf);
+	if (!btf_obj_id)
+		btf_obj_id = fail2_get_kernel_btf_obj_id(module_name);
 
 	printf("Module:%s (BTF-obj ID:%d) Symbol:%s have BTF type id:%d\n",
 	       module_name, btf_obj_id, symbol_name, type_id);

--- a/BTF-playground/btf_module_read.c
+++ b/BTF-playground/btf_module_read.c
@@ -16,11 +16,13 @@
 
 #include <linux/err.h>
 
-static const char *module_name = "tun";
-static const char *symbol_name = "tun_struct";
+static char module_name[128] = "tun";	 	/* Default module to lookup */
+static char symbol_name[128] = "tun_struct";	/* Default symbol to lookup */
 
 static const struct option long_options[] = {
-	{ "debug",	no_argument,	NULL,	'd' },
+	{ "debug",		no_argument,		NULL,	'd' },
+	{ "module-name",	required_argument,	NULL,	'm' },
+	{ "symbol-name",	required_argument,	NULL,	's' },
 	{ 0, 0, NULL, 0 }
 };
 
@@ -97,11 +99,17 @@ int main(int argc, char **argv)
 	int err = 0;
 
 	/* Parse commands line args */
-	while ((opt = getopt_long(argc, argv, "d",
+	while ((opt = getopt_long(argc, argv, "dm:s:",
 				  long_options, &longindex)) != -1) {
 		switch (opt) {
 		case 'd':
 			libbpf_set_print(print_all_levels);
+			break;
+		case 'm': /* --module */
+			strncpy(module_name, optarg, sizeof(module_name) - 1);
+			break;
+		case 's': /* --symbol */
+			strncpy(symbol_name, optarg, sizeof(symbol_name) - 1);
 			break;
 		default:
 			pr_err("Unrecognized option '%s'\n", argv[optind - 1]);


### PR DESCRIPTION
Userspace code (libbpf based) experimenting with looking up the Kernel's BTF **object** *ID* for kernel modules.

This is needed as part of the XDP-hints effort as we are looking at having a "full" u64 BTF ID that comprise of the BTF object ID + BTF type ID (inside the object ID).

- This is done to be able to fully identify which kernel module created the BTF ID.


