### PR TITLE
PPing fix reorder issue

### DIFF
--- a/pping/TODO.md
+++ b/pping/TODO.md
@@ -202,29 +202,6 @@ concurrent packets have different identifiers there may be a lost
 update (but for TCP timestamps, concurrent packets would typically be
 expected to have the same timestamp).
 
-A possibly more severe issue is out-of-order packets. If a packet with
-an old identifier arrives out of order, that identifier could be
-detected as a new identifier. If for example the following flow of
-four packets with just two different identifiers (id1 and id2) were to
-occur:
-
-id1 -> id2 -> id1 -> id2
-
-Then the tc/egress program would consider each of these packets to
-have new identifiers and try to create a new timestamp for each of
-them if the sampling strategy allows it. However even if the sampling
-strategy allows it, the (incorrect) creation of timestamps for id1 and
-id2 the second time would only be successful in case the first
-timestamps for id1 and id2 have already been matched against (and thus
-deleted). Even if that is the case, they would only result in
-reporting an incorrect RTT in case there are also new matches against
-these identifiers.
-
-This issue could be avoided entirely by requiring that new-id > old-id
-instead of simply checking that new-id != old-id, as TCP timestamps
-should monotonically increase. That may however not be a suitable
-solution for other types of identifiers.
-
 ### Rate-limiting new timestamps
 In the tc/egress program packets to timestamp are sampled by using a
 per-flow rate-limit, which is enforced by storing when the last


### PR DESCRIPTION
This PR fixes a potential issue that could cause ePPing to report incorrect RTTs (due to failing to only create a single timestamp per unique TSval). This issue would mainly manifest if the RTT < 1ms, as otherwise the entry in the timestamp map would block other entries with the same TSval from being created. See commit message (and the removed part of the TODO in the second commit) for more details.

This commit adds a little bit of overhead in the form of two `bpf_ntohl()` calls and some more complicated operations for checking if a TSval differs from a previous one (two subtractions (which I suspect the compiler to optimize to one), and two comparisons, plus a check for protocol replaces a single equality comparison). While I have not run any tests to measure the performance impact I do no expect this to add considerable overhead compared to all the other stuff that ePPing does at this point.

I also break away from my own principle of avoiding protocol-specific logic outside of the packet parsing, but in this case it is needed to fix this issue while not negatively impacting the ICMP mode. For ICMP it's not an issue if the packets are reordered, and I don't think the ICMP sequence numbers are required to increment even if that's the most reasonable behavior, so there's no reason to force the monotonically non-decreasing logic for it as well (plus its only 16 bits so it would need separate logic from the TSval's anyways). 