### PR TITLE
PPing: Add option to ignore SYN-packets

### DIFF
--- a/pping/pping.c
+++ b/pping/pping.c
@@ -102,6 +102,7 @@ static const struct option long_options[] = {
 	{ "tcp",              no_argument,       NULL, 'T' }, // Calculate and report RTTs for TCP traffic (with TCP timestamps)
 	{ "icmp",             no_argument,       NULL, 'C' }, // Calculate and report RTTs for ICMP echo-reply traffic
 	{ "include-local",    no_argument,       NULL, 'l' }, // Also report "internal" RTTs
+	{ "include-SYN",      no_argument,       NULL, 's' }, // Include SYN-packets in tracking (may fill up flow state with half-open connections)
 	{ 0, 0, NULL, 0 }
 };
 
@@ -170,8 +171,9 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 	config->force = false;
 	config->bpf_config.track_tcp = false;
 	config->bpf_config.track_icmp = false;
+	config->bpf_config.skip_syn = true;
 
-	while ((opt = getopt_long(argc, argv, "hflTCi:r:R:t:c:F:I:",
+	while ((opt = getopt_long(argc, argv, "hflTCsi:r:R:t:c:F:I:",
 				  long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'i':
@@ -265,6 +267,9 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 			break;
 		case 'C':
 			config->bpf_config.track_icmp = true;
+			break;
+		case 's':
+			config->bpf_config.skip_syn = false;
 			break;
 		case 'h':
 			printf("HELP:\n");

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -64,7 +64,8 @@ struct bpf_config {
 	bool track_tcp;
 	bool track_icmp;
 	bool localfilt;
-	__u32 reserved;
+	bool skip_syn;
+	__u8 reserved[3];
 };
 
 /*

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -106,7 +106,8 @@ struct flow_state {
 	__u32 outstanding_timestamps;
 	enum connection_state conn_state;
 	enum flow_event_reason opening_reason;
-	__u8 reserved[6];
+	bool has_been_timestamped;
+	__u8 reserved[5];
 };
 
 /*

--- a/pping/pping_kern.c
+++ b/pping/pping_kern.c
@@ -339,6 +339,9 @@ static int parse_tcp_identifier(struct parsing_context *pctx,
 	if (parse_tcphdr(&pctx->nh, pctx->data_end, &hdr) < 0)
 		return -1;
 
+	if (config.skip_syn && hdr->syn)
+		return -1;
+
 	if (parse_tcp_ts(hdr, pctx->data_end, &proto_info->pid,
 			 &proto_info->reply_pid) < 0)
 		return -1; //Possible TODO, fall back on seq/ack instead


### PR DESCRIPTION
Add an option for ePPing to ignore TCP SYN packets, so that the
initial handshake phase of the connection is ignored. More details in the commit message.

For now I've only made it an opt-in option, and by default ePPing will still track SYN-packets, and any SYN-flood attacks would cause it to fall apart. The trace used in the paper ["Continuous in-network round-trip time monitoring"](https://dl.acm.org/doi/10.1145/3544216.3544222) suggests that incomplete TCP connections are quite common, so it might be worth considering if ignoring the SYN packets should be the default option. 