### PR TITLE
Prepare for newer libbpf in bpf-examples

### DIFF
--- a/BTF-playground/btf_module_ids.c
+++ b/BTF-playground/btf_module_ids.c
@@ -217,6 +217,9 @@ int find_btf_id_by_name(const char *btf_name, int *btf_size)
 		if (info.name_len == 0) /* Skip non/empty names */
 			continue;
 
+		if (info.kernel_btf == 0) /* Looking for kernel module BTF */
+			continue;
+
 		name = u64_to_ptr(info.name);
 		if (strncmp(name, btf_name, 127) == 0) {
 

--- a/BTF-playground/btf_module_ids.c
+++ b/BTF-playground/btf_module_ids.c
@@ -121,26 +121,6 @@ int __btf_obj_info_via_fd(int fd, struct bpf_btf_info *info)
 #undef SZ
 }
 
-struct btf *open_vmlinux_btf(void)
-{
-	struct btf* btf_obj;
-	int fd;
-
-	//btf_obj = btf_load_vmlinux_from_kernel();
-	btf_obj = btf__load_vmlinux_btf();
-
-	/* *** DOES NOT WORK ***
-	 *
-	 * The struct btf object returned by btf__load_vmlinux_btf() doesn't
-	 * have a file descriptor set we can use.
-	 */
-	fd = btf__fd(btf_obj);
-	if (fd < 0)
-		pr_err("WARN: BTF-obj miss FD(%d)\n", fd);
-
-	return btf_obj;
-}
-
 int walk_all_ids(void)
 {
 	__u32 lookup_id, id = 0;
@@ -260,7 +240,6 @@ int find_btf_id_by_name(const char *btf_name, int *btf_size)
 
 int main(int argc, char **argv)
 {
-//	struct btf *vmlinux_btf;
 	int opt, longindex = 0;
 	int module_btf_id;
 	int module_btf_sz;
@@ -285,8 +264,6 @@ int main(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 
-//	vmlinux_btf = open_vmlinux_btf();
-
 //	err = walk_all_ids();
 
 	module_btf_id = find_btf_id_by_name(module_name, &module_btf_sz);
@@ -298,7 +275,6 @@ int main(int argc, char **argv)
 		       module_btf_id, module_name);
 	}
 
-//	btf__free(vmlinux_btf);
 	if (err)
 		return EXIT_FAILURE;
 	return EXIT_SUCCESS;

--- a/BTF-playground/btf_module_ids.c
+++ b/BTF-playground/btf_module_ids.c
@@ -184,7 +184,7 @@ int find_btf_id_by_name(const char *btf_name, int *btf_size)
 	int fd;
 
 	while (true) {
-		err = bpf_btf_get_next_id(id, &id);
+		err = bpf_btf_get_next_id(id, &id); /* Privileged op */
 		if (err) {
 			if (errno == ENOENT) {
 				err = 0;
@@ -198,11 +198,11 @@ int find_btf_id_by_name(const char *btf_name, int *btf_size)
 			break;
 		}
 
-		fd = bpf_btf_get_fd_by_id(id);
+		fd = bpf_btf_get_fd_by_id(id); /* Privileged op */
 		if (fd < 0) {
 			if (errno == ENOENT)
 				continue;
-			pr_err("can't get BTF object by id (%u): %s",
+			pr_err("can't get BTF object by id (%u): %s\n",
 			       id, strerror(errno));
 			err = -1;
 			break;

--- a/BTF-playground/btf_module_read.c
+++ b/BTF-playground/btf_module_read.c
@@ -148,8 +148,8 @@ int main(int argc, char **argv)
 	if (!btf_obj_id)
 		btf_obj_id = fail2_get_kernel_btf_obj_id(module_name);
 
-	printf("Module:%s (BTF-obj ID:%d) Symbol:%s have BTF type id:%d\n",
-	       module_name, btf_obj_id, symbol_name, type_id);
+	printf("Module:%s Symbol:%s have BTF type id:%d\n",
+	       module_name, symbol_name, type_id);
 
 out:
 	btf__free(module_btf);

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,11 @@ MAKEFLAGS += --no-print-directory
 Q = @
 endif
 
-SUBDIRS := encap-forward lsm-nobpf
+SUBDIRS := encap-forward
+SUBDIRS += lsm-nobpf
+SUBDIRS += nat64-bpf
+SUBDIRS += traffic-pacing-edt
+
 .PHONY: check_submodule help clobber distclean clean $(SUBDIRS)
 
 all: lib $(SUBDIRS)

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ SUBDIRS := encap-forward
 SUBDIRS += ktrace-CO-RE
 SUBDIRS += lsm-nobpf
 SUBDIRS += nat64-bpf
+SUBDIRS += preserve-dscp
 SUBDIRS += traffic-pacing-edt
 
 .PHONY: check_submodule help clobber distclean clean $(SUBDIRS)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,11 @@ SUBDIRS := encap-forward
 SUBDIRS += ktrace-CO-RE
 SUBDIRS += lsm-nobpf
 SUBDIRS += nat64-bpf
+SUBDIRS += pkt-loop-filter
+SUBDIRS += pping
 SUBDIRS += preserve-dscp
+SUBDIRS += tc-basic-classifier
+SUBDIRS += tc-policy
 SUBDIRS += traffic-pacing-edt
 
 .PHONY: check_submodule help clobber distclean clean $(SUBDIRS)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all: lib $(SUBDIRS)
 lib: config.mk check_submodule
 	@echo; echo $@; $(MAKE) -C $@
 
-$(SUBDIRS):
+$(SUBDIRS): lib
 	@echo; echo $@; $(MAKE) -C $@
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ Q = @
 endif
 
 SUBDIRS := encap-forward
+SUBDIRS += ktrace-CO-RE
 SUBDIRS += lsm-nobpf
 SUBDIRS += nat64-bpf
 SUBDIRS += traffic-pacing-edt

--- a/bpf-link-hang/bpf-link-hang.c
+++ b/bpf-link-hang/bpf-link-hang.c
@@ -29,8 +29,8 @@ int main()
         if (bpf_object__load(obj_target))
             goto out;
 
-        target = bpf_object__find_program_by_title(obj_target, "xdp/pass");
-        prog = bpf_object__find_program_by_title(obj_prog, "xdp/pass");
+        target = bpf_object__find_program_by_name(obj_target, "xdp_pass");
+        prog = bpf_object__find_program_by_name(obj_prog, "xdp_pass");
 
         if (!target || !prog)
                 goto out;

--- a/headers/linux/btf.h
+++ b/headers/linux/btf.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
 /* Copyright (c) 2018 Facebook */
-#ifndef _UAPI__LINUX_BTF_H__
-#define _UAPI__LINUX_BTF_H__
+#ifndef __LINUX_BTF_H__
+#define __LINUX_BTF_H__
 
 #include <linux/types.h>
 
@@ -33,13 +33,13 @@ struct btf_type {
 	/* "info" bits arrangement
 	 * bits  0-15: vlen (e.g. # of struct's members)
 	 * bits 16-23: unused
-	 * bits 24-27: kind (e.g. int, ptr, array...etc)
-	 * bits 28-30: unused
+	 * bits 24-28: kind (e.g. int, ptr, array...etc)
+	 * bits 29-30: unused
 	 * bit     31: kind_flag, currently used by
-	 *             struct, union and fwd
+	 *             struct, union, enum, fwd and enum64
 	 */
 	__u32 info;
-	/* "size" is used by INT, ENUM, STRUCT, UNION and DATASEC.
+	/* "size" is used by INT, ENUM, STRUCT, UNION, DATASEC and ENUM64.
 	 * "size" tells the size of the type it is describing.
 	 *
 	 * "type" is used by PTR, TYPEDEF, VOLATILE, CONST, RESTRICT,
@@ -63,7 +63,7 @@ enum {
 	BTF_KIND_ARRAY		= 3,	/* Array	*/
 	BTF_KIND_STRUCT		= 4,	/* Struct	*/
 	BTF_KIND_UNION		= 5,	/* Union	*/
-	BTF_KIND_ENUM		= 6,	/* Enumeration	*/
+	BTF_KIND_ENUM		= 6,	/* Enumeration up to 32-bit values */
 	BTF_KIND_FWD		= 7,	/* Forward	*/
 	BTF_KIND_TYPEDEF	= 8,	/* Typedef	*/
 	BTF_KIND_VOLATILE	= 9,	/* Volatile	*/
@@ -76,6 +76,7 @@ enum {
 	BTF_KIND_FLOAT		= 16,	/* Floating point	*/
 	BTF_KIND_DECL_TAG	= 17,	/* Decl Tag */
 	BTF_KIND_TYPE_TAG	= 18,	/* Type Tag */
+	BTF_KIND_ENUM64		= 19,	/* Enumeration up to 64-bit values */
 
 	NR_BTF_KINDS,
 	BTF_KIND_MAX		= NR_BTF_KINDS - 1,
@@ -186,4 +187,14 @@ struct btf_decl_tag {
        __s32   component_idx;
 };
 
-#endif /* _UAPI__LINUX_BTF_H__ */
+/* BTF_KIND_ENUM64 is followed by multiple "struct btf_enum64".
+ * The exact number of btf_enum64 is stored in the vlen (of the
+ * info in "struct btf_type").
+ */
+struct btf_enum64 {
+	__u32	name_off;
+	__u32	val_lo32;
+	__u32	val_hi32;
+};
+
+#endif /* __LINUX_BTF_H__ */

--- a/ktrace-CO-RE/ktrace01.c
+++ b/ktrace-CO-RE/ktrace01.c
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
 		goto out;
 	}
 
-	prog = bpf_program__next(NULL, obj);
+	prog = bpf_object__next_program(obj, NULL);
 	if (!prog) {
 		pr_err("No program!\n");
 		err = -ENOENT;

--- a/nat64-bpf/nat64.c
+++ b/nat64-bpf/nat64.c
@@ -389,9 +389,9 @@ int main(int argc, char *argv[])
 	num_addr = (cfg.c.v4_prefix | ~cfg.c.v4_mask) - cfg.c.v4_prefix - 2;
 
 	obj->bss->config = cfg.c;
-	bpf_map__resize(obj->maps.v6_state_map, num_addr);
-	bpf_map__resize(obj->maps.v4_reversemap, num_addr);
-	bpf_map__resize(obj->maps.reclaimed_addrs, num_addr);
+	bpf_map__set_max_entries(obj->maps.v6_state_map, num_addr);
+	bpf_map__set_max_entries(obj->maps.v4_reversemap, num_addr);
+	bpf_map__set_max_entries(obj->maps.reclaimed_addrs, num_addr);
 
 	err = nat64_kern__load(obj);
 	if (err) {

--- a/preserve-dscp/preserve-dscp.c
+++ b/preserve-dscp/preserve-dscp.c
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
 		return err;
 	}
 
-	while ((map = bpf_map__next(map, obj))) {
+	while ((map = bpf_object__next_map(obj, map))) {
 		if (strstr(bpf_map__name(map), ".rodata")) {
 			int ip_only = (iftype == ARPHRD_NONE);
 			bpf_map__set_initial_value(map, &ip_only, sizeof(ip_only));

--- a/traffic-pacing-edt/xdp_cpumap_loader.c
+++ b/traffic-pacing-edt/xdp_cpumap_loader.c
@@ -219,7 +219,7 @@ int do_xdp_attach(int ifindex, struct bpf_program *prog, __u32 xdp_flags)
 		return EXIT_FAIL_BPF;
 	}
 
-	err = bpf_set_link_xdp_fd(ifindex, prog_fd, xdp_flags);
+	err = bpf_xdp_attach(ifindex, prog_fd, xdp_flags, NULL);
 	if (err) {
 		fprintf(stderr, "%s(): link set xdp fd failed (err:%d)\n",
 			__func__, err);
@@ -232,7 +232,7 @@ int do_xdp_detach(int ifindex, __u32 xdp_flags)
 {
 	int err;
 
-	err = bpf_set_link_xdp_fd(ifindex, -1, xdp_flags);
+	err = bpf_xdp_detach(ifindex, xdp_flags, NULL);
 	if (err) {
 		fprintf(stderr, "%s(): link set xdp fd failed (err:%d)\n",
 			__func__, err);
@@ -346,7 +346,7 @@ int main(int argc, char **argv)
 	}
 
 	/* Pickup first BPF-program */
-	prog = bpf_program__next(NULL, obj);
+	prog = bpf_object__next_program(obj, NULL);
 	if (!prog) {
 		printf("No program!\n");
 		err = EXIT_FAIL_BPF;


### PR DESCRIPTION
Newer kernels got a new BTF type "kind" (BTF_KIND_ENUM64) and needs a newer libbpf version, else it fails decoding BTF provided by the Linux kernel.

Running libbpf with verbose/debug print statements shows this error:
```
libbpf: Unsupported BTF_KIND:19
libbpf: loading kernel BTF '/boot/vmlinux-5.19.0-bpf-next-xdp-hints+': -22
libbpf: failed to find valid kernel BTF
```

Before we can upgrade the libbpf version, we need to fixup the bpf-examples to use the newer APIs. This PR is a step in that direction, meaning the API conversion isn't fully done.