### PR TITLE
PPing minor userspace fixes

### DIFF
--- a/pping/pping.c
+++ b/pping/pping.c
@@ -1013,7 +1013,7 @@ int main(int argc, char *argv[])
 		.clean_args = { .cleanup_interval = 1 * NS_PER_SECOND,
 				.valid_thread = false },
 		.object_path = "pping_kern.o",
-		.ingress_prog = PROG_INGRESS_XDP,
+		.ingress_prog = PROG_INGRESS_TC,
 		.egress_prog = PROG_EGRESS_TC,
 		.cleanup_ts_prog = "tsmap_cleanup",
 		.cleanup_flow_prog = "flowmap_cleanup",

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -911,6 +911,16 @@ static int load_attach_bpfprogs(struct bpf_object **obj,
 		/* xdp_attach() loads 'obj' through libxdp */
 		err = xdp_attach(*obj, config->ingress_prog, config->ifindex,
 				 &config->xdp_prog, config->xdp_mode);
+		if (err) {
+			fprintf(stderr, "Failed attaching XDP program\n");
+			if (config->xdp_mode == XDP_MODE_NATIVE)
+				fprintf(stderr,
+					"%s may not have driver support for XDP, try --xdp-mode generic instead\n",
+					config->ifname);
+			else
+				fprintf(stderr,
+					"Try updating kernel or use --ingress-hook tc instead\n");
+		}
 	} else {
 		err = bpf_object__load(*obj);
 		if (err) {

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -937,7 +937,7 @@ static int load_attach_bpfprogs(struct bpf_object **obj,
 		fprintf(stderr,
 			"Failed attaching ingress BPF program on interface %s: %s\n",
 			config->ifname, get_libbpf_strerror(err));
-		return err;
+		goto ingress_err;
 	}
 
 	// Attach egress prog
@@ -970,6 +970,8 @@ egress_err:
 		fprintf(stderr,
 			"Failed detaching ingress program from %s: %s\n",
 			config->ifname, get_libbpf_strerror(detach_err));
+ingress_err:
+	bpf_object__close(*obj);
 	return err;
 }
 
@@ -1179,6 +1181,8 @@ cleanup_attached_progs:
 		fprintf(stderr,
 			"Failed removing egress program from interface %s: %s\n",
 			config.ifname, get_libbpf_strerror(detach_err));
+
+	bpf_object__close(obj);
 
 	return (err != 0 && keep_running) || detach_err != 0;
 }


### PR DESCRIPTION
A few unrelated minor fixes to the userspace component of ePPing. Threw them together in the same PR to avoid lots of tiny PRs.

- The first commit fixes an issue where the clsact would not be cleaned up if using tc mode (--ingress-hook tc)
- The second commit adds a small hint suggesting trying a newer kernel or using tc mode if it fails loading the XDP program. This addresses #49.
- The third commit simply adds a couple of calls to `bfp_object__close()` on shutdown/error. I'm not sure if this is really needed when the program ends directly after anyways, but most recent examples seem to do it so figured I'd better do it as well in case it cleans up some resources that's not automatically freed by the kernel when the program ends.

As for the second commit, I'm not sure if it's the best way to address #49. Simone suggested to automatically try to load and attach the tc ingress program in case the XDP one fails. While this should be possible (although a bit more of a hassle) and in some cases quite convenient, I'm not sure if automatically changing user-specified arguments is a good idea (even if it's not done silently) as it might be easy to miss unless paying close attention to stderr, especially if ePPing is started via ex. a script.

A somewhat related discussion is if we should perhaps always try to load the XDP program in native mode (`XDP_MODE_NATIVE`), instead of in unspecified mode (`XDP_MODE_UNSPEC`) which will (silently) fall back on generic XDP if there's no driver support. From some old discussions with Jesper I got the impression that the performance of XDP generic is rather lackluster, and it probably being better to run with tc than with generic XDP. If that's the case I'm not sure if it makes any sense to allow running in XDP generic mode (and also being unclear to the user whether it's is running in native or generic).

Finally, should XDP mode really be the default? It's less likely to work (due to requiring a more recent kernel), does (still not?) work with ex. GRO and may offer worse performance than tc if running in generic mode. Even if it's running in native XDP mode do we really expect it to have much of a performance benefit here anyways? As ePPing only monitors the packets it's always letting all packets through to the kernel anyways (always return `XDP_PASS`), so we don't really benefit from being able to create a fastpath that bypasses the kernel like some other XDP use cases might. So perhaps it makes more sense to have tc as the default instead (which can be changed to XDP by passing -I/--ingress-hook xdp)?