### PR TITLE
Add aggregation option to ePPing

### DIFF
--- a/pping/lhist.h
+++ b/pping/lhist.h
@@ -1,0 +1,122 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef LHIST_H
+#define LHIST_H
+
+#include <stdlib.h>
+#include <math.h>
+#include <linux/types.h>
+
+#include <stdio.h>
+
+/* Count total number of instances in histogram*/
+static __u64 lhist_count(__u32 *bins, size_t size)
+{
+	__u64 count = 0;
+	int i;
+	for (i = 0; i < size; i++)
+		count += bins[i];
+	return count;
+}
+
+static double lhist_bin_midval(int bin_idx, double bin_width, double left_edge)
+{
+	return left_edge + (bin_width / 2) + bin_width * bin_idx;
+}
+
+/* Calculate an approximate minimum value from a linear histogram.
+ * The approximation is the middle of the first non-empty bin. */
+static double lhist_min(__u32 *bins, size_t size, double bin_width,
+			double left_edge)
+{
+	int i;
+
+	for (i = 0; i < size; i++) {
+		if (bins[i] > 0)
+			break;
+	}
+
+	return size < 1 || bins[i] == 0 ?
+		       NAN :
+		       lhist_bin_midval(i, bin_width, left_edge);
+}
+
+/* Calculate an approximate maximum value from a linear histogram.
+ * The approximation is the middle of the last non-empty bin. */
+static double lhist_max(__u32 *bins, size_t size, double bin_width,
+			double left_edge)
+{
+	int i, last_nonempty = 0;
+
+	for (i = 0; i < size; i++) {
+		if (bins[i] > 0)
+			last_nonempty = i;
+	}
+
+	return size < 1 || bins[last_nonempty] == 0 ?
+		       NAN :
+		       lhist_bin_midval(last_nonempty, bin_width, left_edge);
+}
+
+/* Calculate an apporximate arithmetic mean from a linear histogram.
+ * The approximation is based on the assumption that all instances are located
+ * in the middle of their respective bins. */
+static double lhist_mean(__u32 *bins, size_t size, double bin_width,
+			 double left_edge)
+{
+	double sum = 0, mid_val = left_edge + (bin_width / 2);
+	__u64 count = 0;
+	int i;
+
+	for (i = 0; i < size; i++) {
+		count += bins[i];
+		sum += bins[i] * mid_val;
+		mid_val += bin_width;
+	}
+
+	return count ? sum / count : NAN;
+}
+
+/* Calculate an approximate percentile value from a linear histogram.
+ * The approximation is based on the assumption that all instances are located
+ * in the middle of their respective bins. Does linear interpolation for
+ * percentiles located between bins (similar to ex. numpy.percentile) */
+static double lhist_percentile(__u32 *bins, double percentile, size_t size,
+			       double bin_width, double left_edge)
+{
+	__u64 n = lhist_count(bins, size);
+	double virt_idx, ret;
+	int i = 0, next_i;
+	__u64 count = 0;
+
+	if (n < 1)
+		return NAN;
+
+	virt_idx = percentile / 100 * (n - 1);
+
+	/* Check for out of bounds percentiles or rounding errors*/
+	if (virt_idx <= 0)
+		return lhist_min(bins, size, bin_width, left_edge);
+	else if (virt_idx >= n - 1)
+		return lhist_max(bins, size, bin_width, left_edge);
+
+	/* find bin the virtual index should lie in */
+	while (count <= virt_idx) {
+		count += bins[i++];
+	}
+	i--;
+	ret = lhist_bin_midval(i, bin_width, left_edge);
+
+	/* virtual index is between current bin and next (non-empty) bin
+	   (count - 1 < virt_idx < count) */
+	if (virt_idx > count - 1) {
+		/* Find next non-empty bin to interpolate between */
+		next_i = i + 1;
+		while (bins[next_i] == 0) {
+			next_i++;
+		}
+		ret += (virt_idx - (count - 1)) * (next_i - i) * bin_width;
+	}
+	return ret;
+}
+
+#endif

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -23,6 +23,8 @@ static const char *__doc__ =
 #include <sys/signalfd.h>
 #include <sys/timerfd.h>
 #include <sys/epoll.h>
+#include <linux/unistd.h>
+#include <linux/membarrier.h>
 
 #include "json_writer.h"
 #include "pping.h" //common structs for user-space and BPF parts
@@ -105,8 +107,9 @@ struct aggregation_config {
 };
 
 struct aggregation_maps {
-	int map_v4_fd;
-	int map_v6_fd;
+	int map_active_fd;
+	int map_v4_fd[2];
+	int map_v6_fd[2];
 };
 
 // Store configuration values in struct to easily pass around
@@ -1068,9 +1071,9 @@ static void print_histogram(FILE *stream,
 {
 	int i;
 
-	fprintf(stream, "[%llu", rtt_stats->bins[0]);
+	fprintf(stream, "[%u", rtt_stats->bins[0]);
 	for (i = 1; i < n_bins; i++)
-		fprintf(stream, ",%llu", rtt_stats->bins[i]);
+		fprintf(stream, ",%u", rtt_stats->bins[i]);
 	fprintf(stream, "]");
 }
 
@@ -1121,6 +1124,41 @@ merge_percpu_aggreated_rtts(struct aggregated_rtt_stats *percpu_stats,
 	}
 }
 
+// Stolen from BPF selftests
+int kern_sync_rcu(void)
+{
+	return syscall(__NR_membarrier, MEMBARRIER_CMD_SHARED, 0, 0);
+}
+
+/* Changes which map the BPF progs use to aggregate the RTTs in.
+ * On success returns the map idx that the BPF progs used BEFORE the switch
+ * (and thus the map filled with data up until the switch, but no longer
+ * beeing activly used by the BPF progs).
+ * On failure returns a negative error code */
+static int switch_agg_map(int map_active_fd)
+{
+	__u32 prev_map, next_map, key = 0;
+	int err;
+
+	// Get current map being used by BPF progs
+	err = bpf_map_lookup_elem(map_active_fd, &key, &prev_map);
+	if (err)
+		return err;
+
+	// Swap map being used by BPF progs to agg RTTs in
+	next_map = prev_map == 1 ? 0 : 1;
+	err = bpf_map_update_elem(map_active_fd, &key, &next_map, BPF_EXIST);
+	if (err)
+		return err;
+
+	// Wait for current BPF programs to finish
+	// This should garantuee that after this call no BPF progs will attempt
+	// to update the now inactive maps
+	kern_sync_rcu();
+
+	return prev_map;
+}
+
 static void report_aggregated_rtt_mapentry(
 	struct ipprefix_key *prefix, struct aggregated_rtt_stats *percpu_stats,
 	int n_cpus, int af, __u8 prefix_len, __u64 t_monotonic,
@@ -1131,10 +1169,14 @@ static void report_aggregated_rtt_mapentry(
 	merge_percpu_aggreated_rtts(percpu_stats, &merged_stats, n_cpus,
 				    agg_conf->n_bins);
 
-	// Only print prefixes which have RTT samples
-	if (!aggregated_rtt_stats_empty(&merged_stats))
+	// Only print and clear prefixes which have RTT samples
+	if (!aggregated_rtt_stats_empty(&merged_stats)) {
 		print_aggregated_rtts(stdout, t_monotonic, prefix, af,
 				      prefix_len, &merged_stats, agg_conf);
+
+		// Clear out the reported stats
+		memset(percpu_stats, 0, sizeof(*percpu_stats) * n_cpus);
+	}
 }
 
 static int report_aggregated_rtt_map(int map_fd, int af, __u8 prefix_len,
@@ -1149,6 +1191,8 @@ static int report_aggregated_rtt_map(int map_fd, int af, __u8 prefix_len,
 	__u32 count = AGG_BATCH_SIZE;
 	bool remaining_entries = true;
 	int err = 0, i;
+
+	DECLARE_LIBBPF_OPTS(bpf_map_batch_opts, batch_opts, .flags = BPF_EXIST);
 
 	values = calloc(n_cpus, sizeof(*values) * AGG_BATCH_SIZE);
 	keys = calloc(AGG_BATCH_SIZE, keysize);
@@ -1174,6 +1218,12 @@ static int report_aggregated_rtt_map(int map_fd, int af, __u8 prefix_len,
 						       t_monotonic, agg_conf);
 		}
 
+		// Update cleared stats
+		err = bpf_map_update_batch(map_fd, keys, values, &count,
+					   &batch_opts);
+		if (err)
+			goto exit;
+
 		total += count;
 		count = AGG_BATCH_SIZE; // Ensure we always try to fetch full batch
 	}
@@ -1188,14 +1238,18 @@ static int report_aggregated_rtts(struct aggregation_maps *maps,
 				  struct aggregation_config *agg_conf)
 {
 	__u64 t = get_time_ns(CLOCK_MONOTONIC);
-	int err;
+	int err, map_idx;
 
-	err = report_aggregated_rtt_map(maps->map_v4_fd, AF_INET,
+	map_idx = switch_agg_map(maps->map_active_fd);
+	if (map_idx < 0)
+		return map_idx;
+
+	err = report_aggregated_rtt_map(maps->map_v4_fd[map_idx], AF_INET,
 					agg_conf->ipv4_prefix_len, t, agg_conf);
 	if (err)
 		return err;
 
-	err = report_aggregated_rtt_map(maps->map_v6_fd, AF_INET6,
+	err = report_aggregated_rtt_map(maps->map_v6_fd[map_idx], AF_INET6,
 					agg_conf->ipv6_prefix_len, t, agg_conf);
 	return err;
 }
@@ -1466,12 +1520,25 @@ static int handle_pipefd(int pipe_rfd)
 int fetch_aggregation_map_fds(struct bpf_object *obj,
 			      struct aggregation_maps *maps)
 {
-	maps->map_v4_fd = bpf_object__find_map_fd_by_name(obj, "map_v4_agg");
-	maps->map_v6_fd = bpf_object__find_map_fd_by_name(obj, "map_v6_agg");
+	maps->map_active_fd =
+		bpf_object__find_map_fd_by_name(obj, "map_active_agg_instance");
+	maps->map_v4_fd[0] =
+		bpf_object__find_map_fd_by_name(obj, "map_v4_agg1");
+	maps->map_v4_fd[1] =
+		bpf_object__find_map_fd_by_name(obj, "map_v4_agg2");
+	maps->map_v6_fd[0] =
+		bpf_object__find_map_fd_by_name(obj, "map_v6_agg1");
+	maps->map_v6_fd[1] =
+		bpf_object__find_map_fd_by_name(obj, "map_v6_agg2");
 
-	if (maps->map_v4_fd < 0 || maps->map_v6_fd < 0) {
-		fprintf(stderr, "Unable to find aggregation maps (%d/%d).\n",
-			maps->map_v4_fd, maps->map_v6_fd);
+	if (maps->map_active_fd < 0 || maps->map_v4_fd[0] < 0 ||
+	    maps->map_v4_fd[1] < 0 || maps->map_v6_fd[0] < 0 ||
+	    maps->map_v6_fd[1] < 0) {
+		fprintf(stderr,
+			"Unable to find aggregation maps (%d/%d/%d/%d/%d).\n",
+			maps->map_active_fd, maps->map_v4_fd[0],
+			maps->map_v4_fd[1], maps->map_v6_fd[0],
+			maps->map_v6_fd[1]);
 		return -ENOENT;
 	}
 

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -1095,6 +1095,13 @@ static bool aggregated_rtt_stats_nortts(struct aggregated_rtt_stats *stats)
 	return stats->max == 0;
 }
 
+static __u64 aggregated_rtt_stats_maxbins(struct aggregated_rtt_stats *stats,
+					  __u64 bin_width, __u64 n_bins)
+{
+	return stats->max / bin_width < n_bins ? stats->max / bin_width + 1 :
+						 n_bins;
+}
+
 static void
 merge_percpu_aggreated_rtts(struct aggregated_rtt_stats *percpu_stats,
 			    struct aggregated_rtt_stats *merged_stats,
@@ -1141,7 +1148,8 @@ static void print_aggrtts_standard(FILE *stream, __u64 t, const char *prefixstr,
 				   struct aggregated_rtt_stats *rtt_stats,
 				   struct aggregation_config *agg_conf)
 {
-	__u64 nb = agg_conf->n_bins, bw = agg_conf->bin_width;
+	__u64 bw = agg_conf->bin_width;
+	__u64 nb = aggregated_rtt_stats_maxbins(rtt_stats, bw, agg_conf->n_bins);
 
 	print_ns_datetime(stream, t);
 	fprintf(stream,
@@ -1170,7 +1178,8 @@ static void print_aggrtts_json(json_writer_t *ctx, __u64 t,
 			       struct aggregated_rtt_stats *rtt_stats,
 			       struct aggregation_config *agg_conf)
 {
-	__u64 nb = agg_conf->n_bins, bw = agg_conf->bin_width;
+	__u64 bw = agg_conf->bin_width;
+	__u64 nb = aggregated_rtt_stats_maxbins(rtt_stats, bw, agg_conf->n_bins);
 	int i;
 
 	jsonw_start_object(ctx);

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -108,6 +108,7 @@ struct aggregation_config {
 	__u64 bin_width;
 	__u8 ipv4_prefix_len;
 	__u8 ipv6_prefix_len;
+	enum pping_output_format format;
 };
 
 struct aggregation_maps {
@@ -435,6 +436,8 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 	config->bpf_config.ipv6_prefix_mask =
 		htobe64(0xffffffffffffffffUL
 			<< (64 - config->agg_conf.ipv6_prefix_len));
+
+	config->agg_conf.format = config->output_format;
 
 	return 0;
 }
@@ -1070,16 +1073,11 @@ static void handle_missed_events(void *ctx, int cpu, __u64 lost_cnt)
 	fprintf(stderr, "Lost %llu events on CPU %d\n", lost_cnt, cpu);
 }
 
-static void print_aggregated_rtts(FILE *stream, __u64 t,
-				  struct ipprefix_key *prefix, int af,
-				  __u8 prefix_len,
-				  struct aggregated_rtt_stats *rtt_stats,
-				  struct aggregation_config *agg_conf)
+static void print_aggrtts_standard(FILE *stream, __u64 t, const char *prefixstr,
+				   struct aggregated_rtt_stats *rtt_stats,
+				   struct aggregation_config *agg_conf)
 {
 	__u64 nb = agg_conf->n_bins, bw = agg_conf->bin_width;
-	char prefixstr[INET6_PREFIXSTRLEN] = { 0 };
-
-	format_ipprefix(prefixstr, sizeof(prefixstr), af, prefix, prefix_len);
 
 	print_ns_datetime(stream, t);
 	fprintf(stream,
@@ -1091,6 +1089,52 @@ static void print_aggregated_rtts(FILE *stream, __u64 t,
 		lhist_percentile(rtt_stats->bins, 95, nb, bw, 0) / NS_PER_MS,
 		(double)rtt_stats->max / NS_PER_MS);
 	fprintf(stream, "\n");
+}
+
+static void print_aggrtts_json(json_writer_t *ctx, __u64 t,
+			       const char *prefixstr,
+			       struct aggregated_rtt_stats *rtt_stats,
+			       struct aggregation_config *agg_conf)
+{
+	__u64 nb = agg_conf->n_bins, bw = agg_conf->bin_width;
+	int i;
+
+	jsonw_start_object(ctx);
+	jsonw_u64_field(ctx, "timestamp", convert_monotonic_to_realtime(t));
+	jsonw_string_field(ctx, "ip_prefix", prefixstr);
+	jsonw_u64_field(ctx, "count_rtt", lhist_count(rtt_stats->bins, nb));
+	jsonw_u64_field(ctx, "min_rtt", rtt_stats->min);
+	jsonw_float_field(ctx, "mean_rtt",
+			  lhist_mean(rtt_stats->bins, nb, bw, 0));
+	jsonw_float_field(ctx, "median_rtt",
+			  lhist_percentile(rtt_stats->bins, 50, nb, bw, 0));
+	jsonw_float_field(ctx, "p95_rtt",
+			  lhist_percentile(rtt_stats->bins, 95, nb, bw, 0));
+	jsonw_u64_field(ctx, "max_rtt", rtt_stats->max);
+	jsonw_u64_field(ctx, "bin_width", bw);
+
+	jsonw_name(ctx, "histogram");
+	jsonw_start_array(ctx);
+	for (i = 0; i < nb; i++)
+		jsonw_uint(ctx, rtt_stats->bins[i]);
+	jsonw_end_array(ctx);
+
+	jsonw_end_object(ctx);
+}
+
+static void print_aggregated_rtts(__u64 t, struct ipprefix_key *prefix, int af,
+				  __u8 prefix_len,
+				  struct aggregated_rtt_stats *rtt_stats,
+				  struct aggregation_config *agg_conf)
+{
+	char prefixstr[INET6_PREFIXSTRLEN] = { 0 };
+	format_ipprefix(prefixstr, sizeof(prefixstr), af, prefix, prefix_len);
+
+	if (agg_conf->format == PPING_OUTPUT_STANDARD)
+		print_aggrtts_standard(stdout, t, prefixstr, rtt_stats,
+				       agg_conf);
+	else
+		print_aggrtts_json(json_ctx, t, prefixstr, rtt_stats, agg_conf);
 }
 
 static bool aggregated_rtt_stats_empty(struct aggregated_rtt_stats *stats)
@@ -1169,8 +1213,8 @@ static void report_aggregated_rtt_mapentry(
 
 	// Only print and clear prefixes which have RTT samples
 	if (!aggregated_rtt_stats_empty(&merged_stats)) {
-		print_aggregated_rtts(stdout, t_monotonic, prefix, af,
-				      prefix_len, &merged_stats, agg_conf);
+		print_aggregated_rtts(t_monotonic, prefix, af, prefix_len,
+				      &merged_stats, agg_conf);
 
 		// Clear out the reported stats
 		memset(percpu_stats, 0, sizeof(*percpu_stats) * n_cpus);
@@ -1800,10 +1844,16 @@ int main(int argc, char *argv[])
 	if (!config.bpf_config.track_tcp && !config.bpf_config.track_icmp)
 		config.bpf_config.track_tcp = true;
 
-	if (config.bpf_config.track_icmp &&
-	    config.output_format == PPING_OUTPUT_PPVIZ)
-		fprintf(stderr,
-			"Warning: ppviz format mainly intended for TCP traffic, but may now include ICMP traffic as well\n");
+	if (config.output_format == PPING_OUTPUT_PPVIZ) {
+		if (config.bpf_config.agg_rtts) {
+			fprintf(stderr,
+				"The ppviz format does not support aggregated output\n");
+			return EXIT_FAILURE;
+		}
+		if (config.bpf_config.track_icmp)
+			fprintf(stderr,
+				"Warning: ppviz format mainly intended for TCP traffic, but may now include ICMP traffic as well\n");
+	}
 
 	switch (config.output_format) {
 	case PPING_OUTPUT_STANDARD:

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -171,7 +171,7 @@ static int parse_bounded_double(double *res, const char *str, double low,
 static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 {
 	int err, opt;
-	double rate_limit_ms, cleanup_interval_s, rtt_rate;
+	double user_float;
 
 	config->ifindex = 0;
 	config->bpf_config.localfilt = true;
@@ -201,22 +201,21 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 			}
 			break;
 		case 'r':
-			err = parse_bounded_double(&rate_limit_ms, optarg, 0,
+			err = parse_bounded_double(&user_float, optarg, 0,
 						   7 * S_PER_DAY * MS_PER_S,
 						   "rate-limit");
 			if (err)
 				return -EINVAL;
 
-			config->bpf_config.rate_limit =
-				rate_limit_ms * NS_PER_MS;
+			config->bpf_config.rate_limit = user_float * NS_PER_MS;
 			break;
 		case 'R':
-			err = parse_bounded_double(&rtt_rate, optarg, 0, 10000,
-						   "rtt-rate");
+			err = parse_bounded_double(&user_float, optarg, 0,
+						   10000, "rtt-rate");
 			if (err)
 				return -EINVAL;
 			config->bpf_config.rtt_rate =
-				DOUBLE_TO_FIXPOINT(rtt_rate);
+				DOUBLE_TO_FIXPOINT(user_float);
 			break;
 		case 't':
 			if (strcmp(optarg, "min") == 0) {
@@ -230,14 +229,14 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 			}
 			break;
 		case 'c':
-			err = parse_bounded_double(&cleanup_interval_s, optarg,
-						   0, 7 * S_PER_DAY,
+			err = parse_bounded_double(&user_float, optarg, 0,
+						   7 * S_PER_DAY,
 						   "cleanup-interval");
 			if (err)
 				return -EINVAL;
 
 			config->clean_args.cleanup_interval =
-				cleanup_interval_s * NS_PER_SECOND;
+				user_float * NS_PER_SECOND;
 			break;
 		case 'F':
 			if (strcmp(optarg, "standard") == 0) {

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -155,14 +155,22 @@ static int parse_bounded_double(double *res, const char *str, double low,
 				double high, const char *name)
 {
 	char *endptr;
+	errno = 0;
+
 	*res = strtod(str, &endptr);
-	if (strlen(str) != endptr - str) {
+	if (endptr == str || strlen(str) != endptr - str) {
 		fprintf(stderr, "%s %s is not a valid number\n", name, str);
 		return -EINVAL;
 	}
+
+	if (errno == ERANGE) {
+		fprintf(stderr, "%s %s overflowed\n", name, str);
+		return -ERANGE;
+	}
+
 	if (*res < low || *res > high) {
-		fprintf(stderr, "%s must in range [%g, %g]\n", name, low, high);
-		return -EINVAL;
+		fprintf(stderr, "%s must be in range [%g, %g]\n", name, low, high);
+		return -ERANGE;
 	}
 
 	return 0;

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -1144,6 +1144,40 @@ static void clear_aggregated_rtts(struct aggregated_rtt_stats *stats)
 	stats->last_updated = last_updated;
 }
 
+static void print_aggmetadata_standard(FILE *stream,
+				       struct aggregation_config *agg_conf)
+{
+	fprintf(stream,
+		"Aggregating RTTs in histograms with %llu %.6g ms wide bins every %.9g seconds\n",
+		agg_conf->n_bins, (double)agg_conf->bin_width / NS_PER_MS,
+		(double)agg_conf->aggregation_interval / NS_PER_SECOND);
+}
+
+static void print_aggmetadata_json(json_writer_t *ctx,
+				   struct aggregation_config *agg_conf)
+{
+	jsonw_start_object(ctx);
+
+	jsonw_u64_field(ctx, "timestamp", get_time_ns(CLOCK_REALTIME));
+	jsonw_u64_field(ctx, "bins", agg_conf->n_bins);
+	jsonw_u64_field(ctx, "bin_width_ns", agg_conf->bin_width);
+	jsonw_u64_field(ctx, "aggregation_interval_ns",
+			agg_conf->aggregation_interval);
+	jsonw_u64_field(ctx, "timeout_interval_ns", agg_conf->timeout_interval);
+	jsonw_uint_field(ctx, "ipv4_prefix_len", agg_conf->ipv4_prefix_len);
+	jsonw_uint_field(ctx, "ipv6_prefix_len", agg_conf->ipv6_prefix_len);
+
+	jsonw_end_object(ctx);
+}
+
+static void print_aggmetadata(struct aggregation_config *agg_conf)
+{
+	if (agg_conf->format == PPING_OUTPUT_STANDARD)
+		print_aggmetadata_standard(stdout, agg_conf);
+	else
+		print_aggmetadata_json(json_ctx, agg_conf);
+}
+
 static void print_aggrtts_standard(FILE *stream, __u64 t, const char *prefixstr,
 				   struct aggregated_rtt_stats *rtt_stats,
 				   struct aggregation_config *agg_conf)
@@ -1203,7 +1237,6 @@ static void print_aggrtts_json(json_writer_t *ctx, __u64 t,
 	jsonw_float_field(ctx, "p95_rtt",
 			  lhist_percentile(rtt_stats->bins, 95, nb, bw, 0));
 	jsonw_u64_field(ctx, "max_rtt", rtt_stats->max);
-	jsonw_u64_field(ctx, "bin_width", bw);
 
 	jsonw_name(ctx, "histogram");
 	jsonw_start_array(ctx);
@@ -2025,12 +2058,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (config.bpf_config.agg_rtts)
-		fprintf(stderr,
-			"Aggregating RTTs in histograms with %llu %.6g ms wide bins every %.9g seconds\n",
-			config.agg_conf.n_bins,
-			(double)config.agg_conf.bin_width / NS_PER_MS,
-			(double)config.agg_conf.aggregation_interval /
-				NS_PER_SECOND);
+		print_aggmetadata(&config.agg_conf);
 
 	// Setup signalhandling (allow graceful shutdown on SIGINT/SIGTERM)
 	sigfd = init_signalfd();

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -36,7 +36,7 @@ static const char *__doc__ =
 #define PROG_INGRESS_XDP "pping_xdp_ingress"
 #define PROG_EGRESS_TC "pping_tc_egress"
 
-enum PPING_OUTPUT_FORMAT {
+enum pping_output_format {
 	PPING_OUTPUT_STANDARD,
 	PPING_OUTPUT_JSON,
 	PPING_OUTPUT_PPVIZ
@@ -85,7 +85,7 @@ struct pping_config {
 	int ingress_prog_id;
 	int egress_prog_id;
 	char ifname[IF_NAMESIZE];
-	enum PPING_OUTPUT_FORMAT output_format;
+	enum pping_output_format output_format;
 	enum xdp_attach_mode xdp_mode;
 	bool force;
 	bool created_tc_hook;
@@ -317,7 +317,7 @@ const char *tracked_protocols_to_str(struct pping_config *config)
 	return tcp && icmp ? "TCP, ICMP" : tcp ? "TCP" : "ICMP";
 }
 
-const char *output_format_to_str(enum PPING_OUTPUT_FORMAT format)
+const char *output_format_to_str(enum pping_output_format format)
 {
 	switch (format) {
 	case PPING_OUTPUT_STANDARD:

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -11,6 +11,10 @@
 #define MS_PER_S 1000UL
 #define S_PER_DAY (24 * 3600UL)
 
+#define MAP_TIMESTAMP_SIZE 131072UL // 2^17, Maximum number of in-flight/unmatched timestamps we can keep track of
+#define MAP_FLOWSTATE_SIZE 131072UL // 2^17, Maximum number of concurrent flows that can be tracked
+#define MAP_AGGREGATION_SIZE 16384UL // 2^14, Maximum number of different IP-prefixes we can aggregate stats for
+
 typedef __u64 fixpoint64;
 #define FIXPOINT_SHIFT 16
 #define DOUBLE_TO_FIXPOINT(X) ((fixpoint64)((X) * (1UL << FIXPOINT_SHIFT)))
@@ -225,6 +229,7 @@ union pping_event {
 };
 
 struct aggregated_rtt_stats {
+	__u64 last_updated;
 	__u64 min;
 	__u64 max;
 	__u32 bins[RTT_AGG_NR_BINS];

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -230,6 +230,10 @@ union pping_event {
 
 struct aggregated_rtt_stats {
 	__u64 last_updated;
+	__u64 rx_packet_count;
+	__u64 tx_packet_count;
+	__u64 rx_byte_count;
+	__u64 tx_byte_count;
 	__u64 min;
 	__u64 max;
 	__u32 bins[RTT_AGG_NR_BINS];

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -227,7 +227,7 @@ union pping_event {
 struct aggregated_rtt_stats {
 	__u64 min;
 	__u64 max;
-	__u64 bins[RTT_AGG_NR_BINS];
+	__u32 bins[RTT_AGG_NR_BINS];
 };
 
 #endif

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -72,7 +72,7 @@ struct bpf_config {
 	bool skip_syn;
 	bool push_individual_events;
 	bool agg_rtts;
-	__u8 reserved;
+	bool agg_by_dst; // dst of reply packet
 };
 
 struct ipprefix_key {

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -5,6 +5,7 @@
 #include <linux/types.h>
 #include <linux/in6.h>
 #include <stdbool.h>
+#include <endian.h>
 
 #define NS_PER_SECOND 1000000000UL
 #define NS_PER_MS 1000000UL
@@ -28,6 +29,22 @@ typedef __u64 fixpoint64;
 
 #define RTT_AGG_NR_BINS 1000UL
 #define RTT_AGG_BIN_WIDTH (1 * NS_PER_MS) // 1 ms
+
+/* Special IPv4/IPv6 prefixes used for backup entries
+ * To avoid them colliding with and actual traffic (causing the traffic to end
+ * up in the backup entry), use prefixes from blocks reserved for documentation.
+ * Specifically, the prefixes used are:
+ *  - IPv4: 192.0.2.255 (part of 192.0.2.0/24, RFC 5737)
+ *  - IPv6: 2001:db80:ffff:ffff::/64 (part of 2001:db8::/32, RFC 3849) */
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#define IPV4_BACKUP_KEY 0xFF0200C0UL
+#define IPV6_BACKUP_KEY 0xFFFFFFFF80DB0120ULL
+#elif __BYTE_ORDER == __BIG_ENDIAN
+#define IPV4_BACKUP_KEY 0xC00002FFUL
+#define IPV6_BACKUP_KEY 0x2001DB80FFFFFFFFULL
+#else
+#error
+#endif
 
 enum __attribute__((__packed__)) flow_event_type {
 	FLOW_EVENT_NONE,

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -27,8 +27,8 @@ typedef __u64 fixpoint64;
 #define EVENT_TYPE_MAP_FULL 3
 #define EVENT_TYPE_MAP_CLEAN 4
 
-#define RTT_AGG_NR_BINS 1000UL
-#define RTT_AGG_BIN_WIDTH (1 * NS_PER_MS) // 1 ms
+#define RTT_AGG_NR_BINS 250UL
+#define RTT_AGG_BIN_WIDTH (4 * NS_PER_MS)
 
 /* Special IPv4/IPv6 prefixes used for backup entries
  * To avoid them colliding with and actual traffic (causing the traffic to end

--- a/pping/pping_kern.c
+++ b/pping/pping_kern.c
@@ -1020,8 +1020,13 @@ lookup_or_create_aggregation_stats(struct in6_addr *ip, __u8 ipv)
 
 	// No existing entry, try to create new one
 	err = bpf_map_update_elem(agg_map, &key, &empty_stats, BPF_NOEXIST);
-	if (err && err != -EEXIST)
-		return NULL;
+	if (err && err != -EEXIST) {
+		// No space left in aggregation map - switch to backup entry
+		if (ipv == AF_INET)
+			key.v4 = IPV4_BACKUP_KEY;
+		else
+			key.v6 = IPV6_BACKUP_KEY;
+	}
 
 	return bpf_map_lookup_elem(agg_map, &key);
 }

--- a/pping/pping_kern.c
+++ b/pping/pping_kern.c
@@ -159,7 +159,6 @@ struct {
 	__type(key, __u32);
 	__type(value, struct aggregated_rtt_stats);
 	__uint(max_entries, MAP_AGGREGATION_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } map_v4_agg1 SEC(".maps");
 
 struct {
@@ -167,7 +166,6 @@ struct {
 	__type(key, __u32);
 	__type(value, struct aggregated_rtt_stats);
 	__uint(max_entries, MAP_AGGREGATION_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } map_v4_agg2 SEC(".maps");
 
 struct {
@@ -175,7 +173,6 @@ struct {
 	__type(key, __u64);
 	__type(value, struct aggregated_rtt_stats);
 	__uint(max_entries, MAP_AGGREGATION_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } map_v6_agg1 SEC(".maps");
 
 struct {
@@ -183,7 +180,6 @@ struct {
 	__type(key, __u64);
 	__type(value, struct aggregated_rtt_stats);
 	__uint(max_entries, MAP_AGGREGATION_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } map_v6_agg2 SEC(".maps");
 
 struct {

--- a/pping/pping_kern.c
+++ b/pping/pping_kern.c
@@ -43,6 +43,9 @@
 #define ICMP_FLOW_LIFETIME (30 * NS_PER_SECOND) // Clear any ICMP flows if they're inactive this long
 #define UNOPENED_FLOW_LIFETIME (30 * NS_PER_SECOND) // Clear out flows that have not seen a response after this long
 
+#define MAP_TIMESTAMP_SIZE 131072UL // 2^17, Maximum number of in-flight/unmatched timestamps we can keep track of
+#define MAP_FLOWSTATE_SIZE 131072UL // 2^17, Maximum number of concurrent flows that can be tracked
+
 #define MAX_MEMCMP_SIZE 128
 
 /*
@@ -131,14 +134,14 @@ struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, struct packet_id);
 	__type(value, __u64);
-	__uint(max_entries, 16384);
+	__uint(max_entries, MAP_TIMESTAMP_SIZE);
 } packet_ts SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, struct network_tuple);
 	__type(value, struct dual_flow_state);
-	__uint(max_entries, 16384);
+	__uint(max_entries, MAP_FLOWSTATE_SIZE);
 } flow_state SEC(".maps");
 
 struct {

--- a/pping/pping_kern.c
+++ b/pping/pping_kern.c
@@ -1123,7 +1123,10 @@ static void pping_match_packet(struct flow_state *f_state, void *ctx,
 	f_state->srtt = calculate_srtt(f_state->srtt, rtt);
 
 	send_rtt_event(ctx, rtt, f_state, p_info);
-	aggregate_rtt(rtt, &p_info->pid.flow.saddr.ip, p_info->pid.flow.ipv);
+	aggregate_rtt(rtt,
+		      config.agg_by_dst ? &p_info->pid.flow.daddr.ip :
+					  &p_info->pid.flow.saddr.ip,
+		      p_info->pid.flow.ipv);
 }
 
 /*

--- a/pping/pping_kern.c
+++ b/pping/pping_kern.c
@@ -90,6 +90,7 @@ struct parsing_context {
  */
 struct packet_info {
 	__u64 time;                  // Arrival time of packet
+	__u32 pkt_len;               // Size of packet (including headers)
 	__u32 payload;               // Size of packet data (excluding headers)
 	struct packet_id pid;        // flow + identifier to timestamp (ex. TSval)
 	struct packet_id reply_pid;  // rev. flow + identifier to match against (ex. TSecr)
@@ -536,6 +537,7 @@ static int parse_packet_identifier(struct parsing_context *pctx,
 	} transporth_ptr;
 
 	p_info->time = bpf_ktime_get_ns();
+	p_info->pkt_len = pctx->pkt_len;
 	proto = parse_ethhdr(&pctx->nh, pctx->data_end, &eth);
 
 	// Parse IPv4/6 header


### PR DESCRIPTION
This PR adds an initial simple version of aggregating RTTs (instead of dumping every single RTT sample as normally done). It aggregates all RTTs (no option to filter or group the aggregation yet) by adding all samples to a histogram and keeping track of minimum and maximum RTT.

The histogram is of fixed size (`pping.h:AGG_RTT_NR_BINS`) and uses equally wide bins (`pping.h:AGG_RTT_BIN_WIDTH`). The current setting is 1000 bins that are 0.1 ms wide, allowing ePPing to capture RTTs from 0-100ms with 0.1ms resolution (the last bin is half-open, so RTTs > 100 ms will also go there). There is currently no option to configure the histogram from the command line, but it would be easy to at least make the bin-width configurable (nr of bins is trickier as it affects the size of structs used in the map).

- The first commit is just a minor refactor which makes the BPF code easier to follow once the aggregation is added in the next commit.
- The second commit adds an initial version of aggregation which is never reset (so each report contains all RTTs since the start of ePPing).
- The third commit resets the aggregation stats after each report, so each report only contains the RTTs since the last report. To avoid concurrency issues between the userspace and BPF progs two aggregation maps are used so that the BPF progs can use one map while the userspace is reading and clearing the other.

Another point worth mentioning is that the periodical aggregation runs in a separate thread in userspace. Initially I planned to simply replace the main loop in userspace which processes the events with the periodical aggregation instead. However, in addition to RTT and flow events the BPF progs also sends debug/warning events through the same perf-buffer, so the main loop for processing events is still needed to handle these.

A potentially nice side effect of the aggregation running in a separate thread is that it should be possible to both report individual RTTs and aggregated stats at the same time, however I've currently made them mutually exclusive for two reasons:
- The userspace does not write the reports "atomically", parts of the individual and aggregated RTT reports may be split and interleaved.
- I have not bothered to figure out how the aggregated reports should work together with the different formats (default, JSON, ppviz).
So for now using aggregated RTTs explicitly disables reporting of individual RTTs.

Could you a quick look at this relatively soon-ish @tohojo to see if it seems reasonable and does contains any major flaws/errors? It doesn't have to be merged any time soon, but it would be nice if it's not complete rubbish as I start testing the performance of it to have something for the upcoming paper.