### PR TITLE
pping: Fix XDP ingress ifindex

### DIFF
--- a/pping/pping_kern.c
+++ b/pping/pping_kern.c
@@ -1041,7 +1041,7 @@ static void pping_xdp(struct xdp_md *ctx)
 		return;
 
 	p_info.is_ingress = true;
-	p_info.ingress_ifindex = ctx->rx_queue_index;
+	p_info.ingress_ifindex = ctx->ingress_ifindex;
 
 	pping_parsed_packet(ctx, &p_info);
 }


### PR DESCRIPTION
I had accidently set the ifindex incorrectly for the XDP program in [the commit that made the packet parsing global functions](https://github.com/xdp-project/bpf-examples/commit/add888566d110f4a6c79e558b1e0eb6ef84d5bc3). This broke the localfilt functionality when using the XDP ingress hook, as the FIB lookup would fail (or potentially be for the wrong ifindex). So this tiny PR fixes that.