### PR TITLE
Arrange for bind for eth to fall back to 'copy' if 'zerocopy' is not supported

### DIFF
--- a/AF_XDP-forwarding/xsk_fwd.c
+++ b/AF_XDP-forwarding/xsk_fwd.c
@@ -728,7 +728,7 @@ static const struct port_params port_params_default = {
 		.tx_size = XSK_RING_PROD__DEFAULT_NUM_DESCS,
 		.libxdp_flags = 0,
 		.xdp_flags = XDP_FLAGS_DRV_MODE,
-		.bind_flags = XDP_USE_NEED_WAKEUP | XDP_ZEROCOPY,
+		.bind_flags = XDP_USE_NEED_WAKEUP,
 	},
 
 	.bp = NULL,


### PR DESCRIPTION
Issue #78 exposes a problem in that eths which do not support 'zerocopy' cause socket initialization to fail. The fix for this is to drop XDP_ZEROCOPY from the bind flags; this causes libxdp to first try to set up zerocopy mode and it this fails to fall back to copying the packet data.

Signed-off-by: Chris Ward <tjcw@uk.ibm.com>