### PR TITLE
AF_XDP-example: fix XDP prog attach for xdp-skb mode

### DIFF
--- a/AF_XDP-example/xdpsock.c
+++ b/AF_XDP-example/xdpsock.c
@@ -1177,7 +1177,7 @@ static void parse_command_line(int argc, char **argv)
 			opt_poll = 1;
 			break;
 		case 'S':
-			opt_attach_mode |= XDP_MODE_SKB;
+			opt_attach_mode = XDP_MODE_SKB;
 			opt_xdp_bind_flags |= XDP_COPY;
 			break;
 		case 'N':


### PR DESCRIPTION
The attach mode is by default set to XDP_MODE_NATIVE and needs to be overwritten to XDP_MODE_SKB when '-S' option is used. Instead of overwriting the attach mode was ORed and so was always running in NATIVE mode. This patch fixes that.

Signed-off-by: Tirthendu Sarkar <tirthendu.sarkar@intel.com>