### PR TITLE
Ignore dirty libxdp submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,4 @@
 [submodule "lib/xdp-tools"]
 	path = lib/xdp-tools
 	url = https://github.com/xdp-project/xdp-tools
+	ignore = dirty


### PR DESCRIPTION
Make Git ignore untracked files in libxdp submodule, as it's just annoying. "Dirty" changes were already ignored in the libbpf submodule, and I see no reason why they shouldn't also be ignored for libxdp.