### PR TITLE
AF_XDP-example: add multi-buffer support to xdpsock

### DIFF
--- a/AF_XDP-example/xdpsock_kern.c
+++ b/AF_XDP-example/xdpsock_kern.c
@@ -3,8 +3,8 @@
 #include <bpf/bpf_helpers.h>
 #include "xdpsock.h"
 
-/* This XDP program is only needed for the XDP_SHARED_UMEM mode.
- * If you do not use this mode, libbpf can supply an XDP program for you.
+/* This XDP program is only needed for multi-buffer and XDP_SHARED_UMEM modes.
+ * If you do not use these modes, libbpf can supply an XDP program for you.
  */
 
 struct {
@@ -14,11 +14,11 @@ struct {
 	__uint(value_size, sizeof(int));
 } xsks_map SEC(".maps");
 
+int num_socks = 0;
 static unsigned int rr;
 
 SEC("xdp_sock") int xdp_sock_prog(struct xdp_md *ctx)
 {
-	rr = (rr + 1) & (MAX_SOCKS - 1);
-
+	rr = (rr + 1) & (num_socks - 1);
 	return bpf_redirect_map(&xsks_map, rr, XDP_DROP);
 }

--- a/headers/linux/if_xdp.h
+++ b/headers/linux/if_xdp.h
@@ -25,6 +25,12 @@
  * application.
  */
 #define XDP_USE_NEED_WAKEUP (1 << 3)
+/* By setting this option, userspace application indicates that it can
+ * handle multiple descriptors per packet thus enabling AF_XDP to split
+ * multi-buffer XDP frames into multiple Rx descriptors. Without this set
+ * such frames will be dropped.
+ */
+#define XDP_USE_SG	(1 << 4)
 
 /* Flags for xsk_umem_config flags */
 #define XDP_UMEM_UNALIGNED_CHUNK_FLAG (1 << 0)
@@ -107,5 +113,12 @@ struct xdp_desc {
 };
 
 /* UMEM descriptor is __u64 */
+
+/* Flag indicating that the packet continues with the buffer pointed out by the
+ * next frame in the ring. The end of the packet is signalled by setting this
+ * bit to zero. For single buffer packets, every descriptor has 'options' set
+ * to 0 and this maintains backward compatibility.
+ */
+#define XDP_PKT_CONTD (1 << 0)
 
 #endif /* _LINUX_IF_XDP_H */


### PR DESCRIPTION
* Add support for handling multi-buffer packets.
* Add a new CLI option to enable frag support.
* xdpsock_kern.c is modified to use num_socks as updated by userspace application.
* MAX_PKT_SIZE is set as 9728 as supported by many NICs.
* xdpsock_kern.o is loaded for both frags and shared uemem cases.