### PR TITLE
Fix compilation error for arm64

### DIFF
--- a/configure
+++ b/configure
@@ -12,6 +12,7 @@ TMPDIR=$(mktemp -d config.XXXXXX)
 trap 'status=$?; rm -rf $TMPDIR; rm -f $CONFIG; exit $status' EXIT HUP INT QUIT TERM
 
 SUBMODULE_LIBBPF=0
+ARCH_INCLUDES=
 
 check_toolchain()
 {
@@ -36,6 +37,15 @@ check_toolchain()
         echo "ERROR: Need clang version >= 11, found $clang_major_version ($clang_version)"
         exit 1
     fi
+
+    ARCH_NAME=$($CC -print-multiarch 2>/dev/null)
+    if [ -z "$ARCH_INCLUDES" ] && [ -n "$ARCH_NAME" ]; then
+        for dir in $(echo | $CC -Wp,-v -E - 2>&1 | grep '^ '); do
+            local idir
+            idir="${dir}/${ARCH_NAME}"
+            [ -d "$idir" ] && ARCH_INCLUDES="-I${idir} $ARCH_INCLUDES"
+        done
+    fi
     echo "clang: $clang_version"
 
     echo "PKG_CONFIG:=${PKG_CONFIG}" >>$CONFIG
@@ -43,6 +53,7 @@ check_toolchain()
     echo "CLANG:=${CLANG}" >>$CONFIG
     echo "LLC:=${LLC}" >>$CONFIG
     echo "BPFTOOL:=${BPFTOOL}" >>$CONFIG
+    echo "ARCH_INCLUDES:=${ARCH_INCLUDES}" >>$CONFIG
 }
 
 check_elf()
@@ -170,7 +181,7 @@ check_bpf_use_errno()
 int dummy(void *ctx) { return 0; }
 EOF
 
-    compile_err=$($CLANG -target bpf -c $TMPDIR/bpf_use_errno_test.c 2>&1)
+    compile_err=$($CLANG -target bpf ${ARCH_INCLUDES} -c $TMPDIR/bpf_use_errno_test.c 2>&1)
     if [ "$?" -ne "0" ]; then
         echo "*** ERROR - Clang BPF-prog cannot include <errno.h>"
         echo "          - Install missing userspace header file"


### PR DESCRIPTION
For ARM64/AArch64 based systems, as linux header files reside under architecture specific directories, this PR fixes configure script to include right header files.