### PR TITLE
Add ECN counters to ePPing

### DIFF
--- a/pping/TODO.md
+++ b/pping/TODO.md
@@ -270,3 +270,22 @@ replies are processed concurrently, it's possible one of them will
 update the flow-open information and emit a flow opening message, but
 another reply closing the flow without thinking it's ever been opened,
 thus not sending a flow closing message.
+
+### Reporting global counters
+While the global counters use per-CPU maps, and are therefore safe to
+concurrently update in the BPF programs, there is no synchronization
+between the BPF programs updating these stats and the user space
+fetching them. It is therefore possible that the user space reports
+these counters in an inconsistent state, i.e. a BPF program may only
+have updated a subset of all the counters it will update by the time
+the user space process fetches the map. For example, a BPF program
+could have updated the packet count but not the byte count when user
+space reports the stats. In practice these errors should be very
+small, and any updates missed in one report will be included in the
+next, i.e. it has eventual consistency.
+
+This problem could be avoided by using two instances of the maps and
+swapping between them (as done by the aggregation stats), however such
+a solution is a fair bit more complex, and has slightly more overhead
+(needs to perform an initial map lookup to determine which instance of
+a map it should update).

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -245,12 +245,19 @@ union pping_event {
 	struct map_clean_event map_clean_event;
 };
 
+struct traffic_counters {
+	__u64 tcp_ts_pkts;
+	__u64 tcp_ts_bytes;
+	__u64 tcp_nots_pkts;
+	__u64 tcp_nots_bytes;
+	__u64 other_pkts;
+	__u64 other_bytes;
+};
+
 struct aggregated_stats {
 	__u64 last_updated;
-	__u64 rx_packet_count;
-	__u64 tx_packet_count;
-	__u64 rx_byte_count;
-	__u64 tx_byte_count;
+	struct traffic_counters rx_stats;
+	struct traffic_counters tx_stats;
 	__u64 rtt_min;
 	__u64 rtt_max;
 	__u32 rtt_bins[RTT_AGG_NR_BINS];

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -245,15 +245,15 @@ union pping_event {
 	struct map_clean_event map_clean_event;
 };
 
-struct aggregated_rtt_stats {
+struct aggregated_stats {
 	__u64 last_updated;
 	__u64 rx_packet_count;
 	__u64 tx_packet_count;
 	__u64 rx_byte_count;
 	__u64 tx_byte_count;
-	__u64 min;
-	__u64 max;
-	__u32 bins[RTT_AGG_NR_BINS];
+	__u64 rtt_min;
+	__u64 rtt_max;
+	__u32 rtt_bins[RTT_AGG_NR_BINS];
 };
 
 #endif

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -30,6 +30,8 @@ typedef __u64 fixpoint64;
 #define RTT_AGG_NR_BINS 250UL
 #define RTT_AGG_BIN_WIDTH (4 * NS_PER_MS)
 
+#define N_IPPROTOS 256
+
 /* Special IPv4/IPv6 prefixes used for backup entries
  * To avoid them colliding with and actual traffic (causing the traffic to end
  * up in the backup entry), use prefixes from blocks reserved for documentation.
@@ -261,6 +263,20 @@ struct aggregated_stats {
 	__u64 rtt_min;
 	__u64 rtt_max;
 	__u32 rtt_bins[RTT_AGG_NR_BINS];
+};
+
+struct global_counters {
+	__u64 nonip_pkts;
+	__u64 nonip_bytes;
+	__u64 tcp_pkts;
+	__u64 tcp_bytes;
+	__u64 udp_pkts;
+	__u64 udp_bytes;
+	__u64 icmp_pkts;
+	__u64 icmp_bytes;
+	__u64 icmp6_pkts;
+	__u64 icmp6_bytes;
+	__u32 other_ipprotos[N_IPPROTOS];
 };
 
 #endif

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -83,6 +83,12 @@ enum __attribute__((__packed__)) connection_state {
         CONNECTION_STATE_CLOSED
 };
 
+enum pping_error {
+	PPING_ERR_PKTTS_STORE,
+	PPING_ERR_FLOW_CREATE,
+	PPING_ERR_AGGSUBNET_CREATE
+};
+
 struct bpf_config {
 	__u64 rate_limit;
 	fixpoint64 rtt_rate;
@@ -272,8 +278,15 @@ struct ecn_counters {
 	__u64 ce;
 };
 
+struct pping_error_counters {
+	__u64 pktts_store;
+	__u64 flow_create;
+	__u64 agg_subnet_create;
+};
+
 struct global_counters {
 	struct ecn_counters ecn;
+	struct pping_error_counters err;
 	__u64 nonip_pkts;
 	__u64 nonip_bytes;
 	__u64 tcp_pkts;

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -265,7 +265,15 @@ struct aggregated_stats {
 	__u32 rtt_bins[RTT_AGG_NR_BINS];
 };
 
+struct ecn_counters {
+	__u64 no_ect;
+	__u64 ect1;
+	__u64 ect0;
+	__u64 ce;
+};
+
 struct global_counters {
+	struct ecn_counters ecn;
 	__u64 nonip_pkts;
 	__u64 nonip_bytes;
 	__u64 tcp_pkts;

--- a/pping/pping_kern.c
+++ b/pping/pping_kern.c
@@ -1132,16 +1132,16 @@ static void update_aggregate_stats(struct aggregated_stats **src_stats,
 		&p_info->pid.flow.saddr.ip, p_info->pid.flow.ipv);
 	if (*src_stats) {
 		(*src_stats)->last_updated = p_info->time;
-		(*src_stats)->tx_packet_count++;
-		(*src_stats)->tx_byte_count += p_info->pkt_len;
+		(*src_stats)->rx_packet_count++;
+		(*src_stats)->rx_byte_count += p_info->pkt_len;
 	}
 
 	*dst_stats = lookup_or_create_aggregation_stats(
 		&p_info->pid.flow.daddr.ip, p_info->pid.flow.ipv);
 	if (*dst_stats) {
 		(*dst_stats)->last_updated = p_info->time;
-		(*dst_stats)->rx_packet_count++;
-		(*dst_stats)->rx_byte_count += p_info->pkt_len;
+		(*dst_stats)->tx_packet_count++;
+		(*dst_stats)->tx_byte_count += p_info->pkt_len;
 	}
 }
 


### PR DESCRIPTION
Add counters for the 4 ECN code points to the global counters.

This builds on top of PR #100 as it makes use of the global counters that is added there, and makes no sense to merge without first merging #100. I can rebase this whenever #100 is merged.