### PR TITLE
Sync in kernel bpf selftest xdp synproxy fix: erroneous bitmask operation

### DIFF
--- a/headers/vmlinux/vmlinux_net.h
+++ b/headers/vmlinux/vmlinux_net.h
@@ -142,6 +142,7 @@ struct nf_conn {
 enum ip_conntrack_status {
 	/* Connection is confirmed: originating packet has left box */
 	IPS_CONFIRMED_BIT = 3,
+	IPS_CONFIRMED = (1 << IPS_CONFIRMED_BIT),
 };
 
 #endif /* __VMLINUX_NET_H__ */

--- a/xdp-synproxy/README.org
+++ b/xdp-synproxy/README.org
@@ -59,3 +59,29 @@ could be built statically and shipped with xdp-synproxy container.
   =>               50    syncookie_xdp              908  6c6615566a2e0419  XDP_PASS
 #+END_SRC
 
+XDP SYNPROXY can also be deployed in Linux router/Firewall, it requires iptables SYNPROXY to be added in filter table FORWARD chain. see https://youtu.be/Cj7SeviTXrw?si=adZ0FrGq84Ygmmy0 for example.
+
+#+BEGIN_SRC sh
+   sudo sysctl -w net.ipv4.ip_forward=1
+   sudo sysctl -w net.ipv4.tcp_syncookies=2
+   sudo sysctl -w net.ipv4.tcp_timestamps=1
+   sudo sysctl -w net.netfilter.nf_conntrack_tcp_loose=0
+   sudo iptables -t raw -I PREROUTING -i ens7 -p tcp -m tcp --syn --dport 80 -j CT --notrack
+   sudo iptables -t filter -A FORWARD -i ens7 -p tcp -m tcp --dport 80 -m state --state INVALID,UNTRACKED -j SYNPROXY --sack-perm --timestamp --wscale 7 --mss 1460
+   sudo iptables -t filter -A FORWARD -i ens7 -m state --state INVALID -j DROP
+   sudo ./xdp_synproxy --iface ens7 --ports 80 --mss4 1460 --mss6 1440 --wscale 7 --ttl 64
+
+   Simple test diagram
+
+   client:                                                  server:
+   ip r add 10.6.6.0/24                                     ip r add 10.3.3.0/24
+      via 10.3.3.8                                             via 10.6.6.8
+
+   +---------------+      +----------------------------+    +--------------+
+   |               |      |                            |    |              |
+   | client        |      |     Firewall/router        |    |  server      |
+   | 10.3.3.9      eno2---ens7 10.3.3.8   10.6.6.8  ens9----ens9 10.6.6.6  |
+   |               |      |                            |    |              |
+   |               |      |                            |    |              |
+   +---------------+      +----------------------------+    +--------------+
+#+END_SRC

--- a/xdp-synproxy/xdp_synproxy_kern.c
+++ b/xdp-synproxy/xdp_synproxy_kern.c
@@ -447,13 +447,13 @@ static __always_inline int tcp_lookup(void *ctx, struct header_pointers *hdr, bo
 		unsigned long status = ct->status;
 
 		bpf_ct_release(ct);
-		if (status & IPS_CONFIRMED_BIT)
+		if (status & IPS_CONFIRMED)
 			return XDP_PASS;
 	} else if (ct_lookup_opts.error != -ENOENT) {
 		return XDP_ABORTED;
 	}
 
-	/* error == -ENOENT || !(status & IPS_CONFIRMED_BIT) */
+	/* error == -ENOENT || !(status & IPS_CONFIRMED) */
 	return XDP_TX;
 }
 


### PR DESCRIPTION
from [Bug in xdp synproxy kernel code](https://marc.info/?t=170084715900001&r=1&w=2), a bug is found when xdp synproxy is required to handle SYNACK from backend server,  and fix is accepted in kernel, sync the fix here. 

also add doc on adding iptables SYNPROXY in filter table FORWARD chain, and attach the xdp synproxy to the client side/internet side router/firewall interface to accelerate synproxy in XDP to protect backend server