### PR TITLE
Netstacklat: Add filtering and grouping

### DIFF
--- a/headers/vmlinux/vmlinux_net.h
+++ b/headers/vmlinux/vmlinux_net.h
@@ -26,6 +26,22 @@ typedef unsigned char *sk_buff_data_t;
 #endif
 */
 
+struct sk_buff_list {
+	struct sk_buff *next;
+	struct sk_buff *prev;
+};
+
+struct sk_buff_head {
+	union {
+		struct {
+			struct sk_buff *next;
+			struct sk_buff *prev;
+		};
+		struct sk_buff_list list;
+	};
+	__u32 qlen;
+};
+
 struct sk_buff {
 	union {
 		struct {
@@ -174,6 +190,13 @@ struct sock_common {
 
 struct sock {
 	struct sock_common __sk_common;
+	struct sk_buff_head sk_receive_queue;
+	struct {
+		atomic_t rmem_alloc;
+		int len;
+		struct sk_buff *head;
+		struct sk_buff *tail;
+	} sk_backlog;
 	struct dst_entry *sk_rx_dst;
 	int sk_rx_dst_ifindex;
 	u32 sk_rx_dst_cookie;

--- a/headers/vmlinux/vmlinux_net.h
+++ b/headers/vmlinux/vmlinux_net.h
@@ -3,6 +3,15 @@
 
 typedef __u32 __wsum;
 
+typedef struct {
+	struct net *net;
+} possible_net_t;
+
+struct net_device {
+	int ifindex;
+	possible_net_t nd_net;
+};
+
 typedef unsigned int sk_buff_data_t; // Assumes 64-bit. FIXME see below
 /*
 // BITS_PER_LONG can be wrong with -target bpf
@@ -147,10 +156,24 @@ enum ip_conntrack_status {
 };
 
 struct scm_timestamping_internal {
-        struct timespec64 ts[3];
+	struct timespec64 ts[3];
+};
+
+struct ns_common {
+	struct dentry *stashed;
+	unsigned int inum;
+};
+
+struct net {
+	struct ns_common ns;
+};
+
+struct sock_common {
+	possible_net_t skc_net;
 };
 
 struct sock {
+	struct sock_common __sk_common;
 	struct dst_entry *sk_rx_dst;
 	int sk_rx_dst_ifindex;
 	u32 sk_rx_dst_cookie;

--- a/headers/vmlinux/vmlinux_net.h
+++ b/headers/vmlinux/vmlinux_net.h
@@ -150,4 +150,10 @@ struct scm_timestamping_internal {
         struct timespec64 ts[3];
 };
 
+struct sock {
+	struct dst_entry *sk_rx_dst;
+	int sk_rx_dst_ifindex;
+	u32 sk_rx_dst_cookie;
+};
+
 #endif /* __VMLINUX_NET_H__ */

--- a/netstacklat/fill_filter_maps.sh
+++ b/netstacklat/fill_filter_maps.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+declare -rA bpf_maps=(
+    [pid]="netstack_pidfil"
+    [iface]="netstack_ifinde"
+    [cgroup]="netstack_cgroup"
+)
+
+declare -rA key_converters=(
+    [pid]=pid_to_bpftool
+    [iface]=iface_to_bpftool
+    [cgroup]=cgroup_to_bpftool
+)
+
+print_usage()
+{
+    echo "usage: $0 TYPE val1 [val2 val3 val4...]"
+    echo "TYPE: { $(echo "${!bpf_maps[@]}" | tr ' ' '\|') }"
+}
+
+pid_to_bpftool()
+{
+    local val="$1"
+
+    uint_to_bpftool_u32 "$val"
+}
+
+# Supports ifname or ifindex
+iface_to_bpftool()
+{
+    local val="$1"
+
+    if ! is_uint "$val"; then
+        val="$(ifname_to_idx "$val")"
+    fi
+
+    uint_to_bpftool_u32 "$val"
+}
+
+# Supports full cgroup path or direct cgroup id (inode)
+cgroup_to_bpftool()
+{
+    local val="$1"
+
+    if ! is_uint "$val"; then
+        val="$(cgroup_path_to_id "$val")"
+    fi
+
+    uint_to_bpftool_u64 "$val"
+}
+
+is_uint()
+{
+    local val="$1"
+
+    [[ "$val" == +([0-9]) ]]
+}
+
+ifname_to_idx()
+{
+    local ifname="$1"
+    local ifindex=0
+
+    ifindex="$(ip address show "$ifname" | grep "[0-9][0-9]*: ${ifname}.*: <")"
+    ifindex="${ifindex%%:*}"
+
+    if [[ -z "$ifindex" ]]; then
+        return 1
+    fi
+
+    echo "$ifindex"
+}
+
+cgroup_path_to_id()
+{
+    local cpath="$1"
+
+    stat -L -c '%i' "$(realpath "$cpath")"
+}
+
+# When providing keys/values to bpftool map update, it basically wants one
+# argument for each byte in the key/value. So if you have a u32 key (as in any
+# array map) and you want to update key 1234, then you will have to provide
+# key 0xd2 0x04 0x00 0x00 (1234 in hex split up as the 4 bytes in a u32 in
+# little-endian order). These helpers assume you're on a little endian machine.
+uint_to_bpftool_u32()
+{
+    local val="$1"
+
+    printf "0x%02x 0x%02x 0x%02x 0x%02x\n" \
+           $((val & 0xff)) $(((val >> 8) & 0xff)) $(((val >> 16) & 0xff)) $(((val >> 24) & 0xff))
+}
+
+uint_to_bpftool_u64()
+{
+    local val="$1"
+
+    printf "0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x\n" \
+           $((val & 0xff)) $(((val >> 8) & 0xff)) $(((val >> 16) & 0xff)) $(((val >> 24) & 0xff)) \
+           $(((val >> 32) & 0xff)) $(((val >> 40) & 0xff)) $(((val >> 48) & 0xff)) $(((val >> 56) & 0xff))
+}
+
+add_to_filter_map()
+{
+    local map="$1"
+    local key="$2"
+
+    # All the filter maps use a u64 as value
+    # Set the value to 1 to indicate that the key should be included in the filter
+    bpftool map update name "$map" key $key value $(uint_to_bpftool_u64 1)
+}
+
+if (( $# < 2 )); then
+    print_usage
+    exit 1
+fi
+
+type=$1
+if [[ -z "${bpf_maps[$type]}" ]]; then
+    echo "Error: unrecognized type $type, must be one of: ${!bpf_maps[*]}"
+    exit 1
+fi
+
+if [ $(printf '\1' | od -dAn) -ne 1 ]; then
+    echo "Only little-endian systems supported"
+    exit 1
+fi
+
+map=${bpf_maps[$type]}
+converter=${key_converters[$type]}
+
+for val in "${@:2}"; do
+    key=$($converter "$val")
+    if ! add_to_filter_map "$map" "$key"; then
+        echo "Error adding $val ($key) to map $map"
+        exit 1
+    fi
+done

--- a/netstacklat/netstacklat.bpf.c
+++ b/netstacklat/netstacklat.bpf.c
@@ -21,6 +21,7 @@ volatile const struct netstacklat_bpf_config user_config = {
 	.filter_pid = false,
 	.filter_ifindex = false,
 	.filter_cgroup = false,
+	.groupby_ifindex = false,
 };
 
 /*
@@ -38,7 +39,7 @@ struct sk_buff___old {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-	__uint(max_entries, HIST_NBUCKETS * NETSTACKLAT_N_HOOKS);
+	__uint(max_entries, HIST_NBUCKETS * NETSTACKLAT_N_HOOKS * 16);
 	__type(key, struct hist_key);
 	__type(value, u64);
 } netstack_latency_seconds SEC(".maps");
@@ -137,18 +138,17 @@ static ktime_t time_since(ktime_t tstamp)
 	return now - tstamp;
 }
 
-static void record_latency(ktime_t latency, enum netstacklat_hook hook)
+static void record_latency(ktime_t latency, const struct hist_key *key)
 {
-	struct hist_key key = { .hook = hook };
-	increment_exp2_histogram_nosync(&netstack_latency_seconds, key, latency,
+	increment_exp2_histogram_nosync(&netstack_latency_seconds, *key, latency,
 					HIST_MAX_LATENCY_SLOT);
 }
 
-static void record_latency_since(ktime_t tstamp, enum netstacklat_hook hook)
+static void record_latency_since(ktime_t tstamp, const struct hist_key *key)
 {
 	ktime_t latency = time_since(tstamp);
 	if (latency >= 0)
-		record_latency(latency, hook);
+		record_latency(latency, key);
 }
 
 static bool filter_ifindex(u32 ifindex)
@@ -190,6 +190,9 @@ static bool filter_network_ns(struct sk_buff *skb, struct sock *sk)
 
 static void record_skb_latency(struct sk_buff *skb, struct sock *sk, enum netstacklat_hook hook)
 {
+	struct hist_key key = { .hook = hook };
+	u32 ifindex;
+
 	if (bpf_core_field_exists(skb->tstamp_type)) {
 		/*
 		 * For kernels >= v6.11 the tstamp_type being non-zero
@@ -213,13 +216,17 @@ static void record_skb_latency(struct sk_buff *skb, struct sock *sk, enum netsta
 			return;
 	}
 
-	if (!filter_ifindex(skb->skb_iif))
+	ifindex = skb->skb_iif;
+	if (!filter_ifindex(ifindex))
 		return;
 
 	if (!filter_network_ns(skb, sk))
 		return;
 
-	record_latency_since(skb->tstamp, hook);
+	if (user_config.groupby_ifindex)
+		key.ifindex = ifindex;
+
+	record_latency_since(skb->tstamp, &key);
 }
 
 static bool filter_pid(u32 pid)
@@ -298,6 +305,7 @@ static bool filter_min_sockqueue_len(struct sock *sk)
 static void record_socket_latency(struct sock *sk, struct sk_buff *skb,
 				  ktime_t tstamp, enum netstacklat_hook hook)
 {
+	struct hist_key key = { .hook = hook };
 	u32 ifindex;
 
 	if (!filter_min_sockqueue_len(sk))
@@ -313,7 +321,10 @@ static void record_socket_latency(struct sock *sk, struct sk_buff *skb,
 	if (!filter_network_ns(skb, sk))
 		return;
 
-	record_latency_since(tstamp, hook);
+	if (user_config.groupby_ifindex)
+		key.ifindex = ifindex;
+
+	record_latency_since(tstamp, &key);
 }
 
 SEC("fentry/ip_rcv_core")

--- a/netstacklat/netstacklat.bpf.c
+++ b/netstacklat/netstacklat.bpf.c
@@ -41,7 +41,7 @@ struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(max_entries, PID_MAX_LIMIT);
 	__type(key, u32);
-	__type(value, u8);
+	__type(value, u64);
 } netstack_pidfilter SEC(".maps");
 
 static u64 *lookup_or_zeroinit_histentry(void *map, const struct hist_key *key)
@@ -161,7 +161,7 @@ static void record_skb_latency(struct sk_buff *skb, enum netstacklat_hook hook)
 
 static bool filter_pid(u32 pid)
 {
-	u8 *pid_ok;
+	u64 *pid_ok;
 
 	if (!user_config.filter_pid)
 		// No PID filter - all PIDs ok

--- a/netstacklat/netstacklat.bpf.c
+++ b/netstacklat/netstacklat.bpf.c
@@ -301,26 +301,19 @@ int BPF_PROG(netstacklat_udpv6_rcv, struct sk_buff *skb)
 	return 0;
 }
 
-SEC("fexit/tcp_data_queue")
-int BPF_PROG(netstacklat_tcp_data_queue, struct sock *sk, struct sk_buff *skb)
+SEC("fexit/tcp_queue_rcv")
+int BPF_PROG(netstacklat_tcp_queue_rcv, struct sock *sk, struct sk_buff *skb)
 {
 	record_skb_latency(skb, NETSTACKLAT_HOOK_TCP_SOCK_ENQUEUED);
 	return 0;
 }
 
-SEC("fexit/udp_queue_rcv_one_skb")
-int BPF_PROG(netstacklat_udp_queue_rcv_one_skb, struct sock *sk,
-	     struct sk_buff *skb)
+SEC("fexit/__udp_enqueue_schedule_skb")
+int BPF_PROG(netstacklat_udp_enqueue_schedule_skb, struct sock *sk,
+	     struct sk_buff *skb, int retval)
 {
-	record_skb_latency(skb, NETSTACKLAT_HOOK_UDP_SOCK_ENQUEUED);
-	return 0;
-}
-
-SEC("fexit/udpv6_queue_rcv_one_skb")
-int BPF_PROG(netstacklat_udpv6_queue_rcv_one_skb, struct sock *sk,
-	     struct sk_buff *skb)
-{
-	record_skb_latency(skb, NETSTACKLAT_HOOK_UDP_SOCK_ENQUEUED);
+	if (retval == 0)
+		record_skb_latency(skb, NETSTACKLAT_HOOK_UDP_SOCK_ENQUEUED);
 	return 0;
 }
 

--- a/netstacklat/netstacklat.c
+++ b/netstacklat/netstacklat.c
@@ -10,6 +10,7 @@ static const char *__doc__ =
 #include <math.h>
 #include <getopt.h>
 #include <ctype.h>
+#include <net/if.h>
 #include <sys/signalfd.h>
 #include <sys/timerfd.h>
 #include <sys/epoll.h>
@@ -48,8 +49,9 @@ static const char *__doc__ =
 
 #define MAX_HOOK_PROGS 4
 
-// Maximum number of different pids that can be filtered for
-#define MAX_FILTER_PIDS 4096
+// Maximum number of PIDs to read from user
+#define MAX_PARSED_PIDS 4096
+#define MAX_PARSED_IFACES 4096
 
 typedef int (*t_parse_val_func)(const char *, void *);
 
@@ -74,7 +76,9 @@ struct netstacklat_config {
 	double report_interval_s;
 	bool enabled_hooks[NETSTACKLAT_N_HOOKS];
 	int npids;
-	__u32 pids[MAX_FILTER_PIDS];
+	int nifindices;
+	__u32 pids[MAX_PARSED_PIDS];
+	__u32 ifindices[MAX_PARSED_IFACES];
 };
 
 static const struct option long_options[] = {
@@ -84,6 +88,7 @@ static const struct option long_options[] = {
 	{ "enable-probes",   required_argument, NULL, 'e' },
 	{ "disable-probes",  required_argument, NULL, 'd' },
 	{ "pids",            required_argument, NULL, 'p' },
+	{ "interfaces",      required_argument, NULL, 'i' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -408,6 +413,40 @@ static int parse_pids(size_t size, __u32 arr[size], const char *str)
 				    parse_pid);
 }
 
+static int parse_iface(const char *str, void *ifindexout)
+{
+	int ifindex, err = 0;
+	long long lval;
+
+	ifindex = if_nametoindex(str);
+	if (ifindex > IFINDEX_MAX) {
+		fprintf(stderr,
+			"%s has ifindex %d which is above the supported limit %d\n",
+			str, ifindex, IFINDEX_MAX);
+		return -ENOTSUP;
+	} else if (ifindex == 0) {
+		// Not a valid interface name - try parsing it as an index instead
+		err = parse_bounded_long(&lval, str, 1, IFINDEX_MAX,
+					 "interface");
+		if (!err)
+			ifindex = lval;
+	}
+
+	if (ifindex > 0)
+		*(__u32 *)ifindexout = ifindex;
+	else
+		fprintf(stderr,
+			"%s is not a recognized interface name, nor a valid interface index\n",
+			str);
+
+	return err;
+}
+
+static int parse_ifaces(size_t size, __u32 arr[size], const char *str)
+{
+	return parse_strlist_to_arr(str, arr, size, sizeof(*arr), ",", parse_iface);
+}
+
 static int parse_arguments(int argc, char *argv[],
 			   struct netstacklat_config *conf)
 {
@@ -418,7 +457,9 @@ static int parse_arguments(int argc, char *argv[],
 	double fval;
 
 	conf->npids = 0;
+	conf->nifindices = 0;
 	conf->bpf_conf.filter_pid = false;
+	conf->bpf_conf.filter_ifindex = false;
 
 	for (i = 0; i < NETSTACKLAT_N_HOOKS; i++)
 		// All probes enabled by default
@@ -464,7 +505,7 @@ static int parse_arguments(int argc, char *argv[],
 				conf->enabled_hooks[i] = !hooks[i];
 			hooks_off = true;
 			break;
-		case 'p': // filter-pids
+		case 'p': // pids
 			ret = parse_pids(ARRAY_SIZE(conf->pids) - conf->npids,
 					 conf->pids + conf->npids, optarg);
 			if (ret < 0)
@@ -472,6 +513,16 @@ static int parse_arguments(int argc, char *argv[],
 
 			conf->npids += ret;
 			conf->bpf_conf.filter_pid = true;
+			break;
+		case 'i': // interfaces
+			ret = parse_ifaces(
+				ARRAY_SIZE(conf->ifindices) - conf->nifindices,
+				conf->ifindices + conf->nifindices, optarg);
+			if (ret < 0)
+				return ret;
+
+			conf->nifindices += ret;
+			conf->bpf_conf.filter_ifindex = true;
 			break;
 		case 'h': // help
 			print_usage(stdout, argv[0]);
@@ -1120,6 +1171,16 @@ int main(int argc, char *argv[])
 	if (err) {
 		libbpf_strerror(err, errmsg, sizeof(errmsg));
 		fprintf(stderr, "Failed filling the pid filter map: %s\n",
+			errmsg);
+		goto exit_destroy_bpf;
+	}
+
+	err = init_filtermap(bpf_map__fd(obj->maps.netstack_ifindexfilter),
+			     config.ifindices, config.nifindices,
+			     sizeof(*config.ifindices));
+	if (err) {
+		libbpf_strerror(err, errmsg, sizeof(errmsg));
+		fprintf(stderr, "Failed filling the ifindex filter map: %s\n",
 			errmsg);
 		goto exit_destroy_bpf;
 	}

--- a/netstacklat/netstacklat.c
+++ b/netstacklat/netstacklat.c
@@ -92,6 +92,7 @@ static const struct option long_options[] = {
 	{ "interfaces",        required_argument, NULL, 'i' },
 	{ "network-namespace", required_argument, NULL, 'n' },
 	{ "cgroups",           required_argument, NULL, 'c' },
+	{ "min-queuelength",   required_argument, NULL, 'q' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -550,10 +551,12 @@ static int parse_arguments(int argc, char *argv[],
 	long long network_ns = 0;
 	int opt, err, ret, i;
 	char optstr[64];
+	long long lval;
 	double fval;
 
 	conf->npids = 0;
 	conf->nifindices = 0;
+	conf->bpf_conf.filter_min_sockqueue_len = 0;
 	conf->bpf_conf.filter_pid = false;
 	conf->bpf_conf.filter_ifindex = false;
 	conf->bpf_conf.filter_cgroup = false;
@@ -637,6 +640,13 @@ static int parse_arguments(int argc, char *argv[],
 
 			conf->ncgroups += ret;
 			conf->bpf_conf.filter_cgroup = true;
+			break;
+		case 'q': // min-queuelength
+			err = parse_bounded_long(&lval, optarg, 0, 65536,
+						 optval_to_longopt(opt)->name);
+			if (err)
+				return err;
+			conf->bpf_conf.filter_min_sockqueue_len = lval;
 			break;
 		case 'h': // help
 			print_usage(stdout, argv[0]);

--- a/netstacklat/netstacklat.c
+++ b/netstacklat/netstacklat.c
@@ -93,6 +93,7 @@ static const struct option long_options[] = {
 	{ "network-namespace", required_argument, NULL, 'n' },
 	{ "cgroups",           required_argument, NULL, 'c' },
 	{ "min-queuelength",   required_argument, NULL, 'q' },
+	{ "groupby-interface", no_argument,       NULL, 'I' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -560,6 +561,7 @@ static int parse_arguments(int argc, char *argv[],
 	conf->bpf_conf.filter_pid = false;
 	conf->bpf_conf.filter_ifindex = false;
 	conf->bpf_conf.filter_cgroup = false;
+	conf->bpf_conf.groupby_ifindex = false;
 
 	for (i = 0; i < NETSTACKLAT_N_HOOKS; i++)
 		// All probes enabled by default
@@ -647,6 +649,9 @@ static int parse_arguments(int argc, char *argv[],
 			if (err)
 				return err;
 			conf->bpf_conf.filter_min_sockqueue_len = lval;
+			break;
+		case 'I': // groupby-interface
+			conf->bpf_conf.groupby_ifindex = true;
 			break;
 		case 'h': // help
 			print_usage(stdout, argv[0]);
@@ -818,13 +823,22 @@ static void print_log2hist(FILE *stream, size_t n, const __u64 hist[n],
 static void print_histkey(FILE *stream, const struct hist_key *key)
 {
 	fprintf(stream, "%s", hook_to_str(key->hook));
+
+	if (key->ifindex)
+		fprintf(stream, ", interface=%u", key->ifindex);
 }
 
 static int cmp_histkey(const void *val1, const void *val2)
 {
 	const struct hist_key *key1 = val1, *key2 = val2;
 
-	return key1->hook == key2->hook ? 0 : key1->hook > key2->hook ? 1 : -1;
+	if (key1->hook != key2->hook)
+		return key1->hook > key2->hook ? 1 : -1;
+
+	if (key1->ifindex != key2->ifindex)
+		return key1->ifindex > key2->ifindex ? 1 : -1;
+
+	return 0;
 }
 
 static int cmp_histentry(const void *val1, const void *val2)
@@ -1017,6 +1031,11 @@ static int init_histogram_buffer(struct histogram_buffer *buf,
 		if (conf->enabled_hooks[i])
 			max_hists++;
 	}
+
+	if (conf->bpf_conf.groupby_ifindex)
+		max_hists *= conf->bpf_conf.filter_ifindex ?
+				     min(conf->nifindices, 64) :
+				     32;
 
 	buf->hists = calloc(max_hists, sizeof(*buf->hists));
 	if (!buf->hists)

--- a/netstacklat/netstacklat.c
+++ b/netstacklat/netstacklat.c
@@ -251,14 +251,13 @@ static void hook_to_progs(struct hook_prog_collection *progs,
 		progs->nprogs = 2;
 		break;
 	case NETSTACKLAT_HOOK_TCP_SOCK_ENQUEUED:
-		progs->progs[0] = obj->progs.netstacklat_tcp_data_queue;
+		progs->progs[0] = obj->progs.netstacklat_tcp_queue_rcv;
 		progs->nprogs = 1;
 		break;
 	case NETSTACKLAT_HOOK_UDP_SOCK_ENQUEUED:
-		progs->progs[0] = obj->progs.netstacklat_udp_queue_rcv_one_skb;
-		progs->progs[1] =
-			obj->progs.netstacklat_udpv6_queue_rcv_one_skb;
-		progs->nprogs = 2;
+		progs->progs[0] =
+			obj->progs.netstacklat_udp_enqueue_schedule_skb;
+		progs->nprogs = 1;
 		break;
 	case NETSTACKLAT_HOOK_TCP_SOCK_READ:
 		progs->progs[0] = obj->progs.netstacklat_tcp_recv_timestamp;

--- a/netstacklat/netstacklat.h
+++ b/netstacklat/netstacklat.h
@@ -36,6 +36,15 @@
 	})
 #endif
 
+#ifndef min
+#define min(a, b)                   \
+	({                          \
+		typeof(a) _a = (a); \
+		typeof(b) _b = (b); \
+		_a < _b ? _a : _b;  \
+	})
+#endif
+
 enum netstacklat_hook {
 	NETSTACKLAT_HOOK_INVALID = 0,
 	NETSTACKLAT_HOOK_IP_RCV,
@@ -54,6 +63,7 @@ enum netstacklat_hook {
  * member is named "bucket" and is the histogram bucket index.
  */
 struct hist_key {
+	__u32 ifindex;
 	__u16 hook; // need well defined size for ebpf-exporter to decode
 	__u16 bucket; // needs to be last to be compatible with ebpf-exporter
 };
@@ -64,6 +74,7 @@ struct netstacklat_bpf_config {
 	bool filter_pid;
 	bool filter_ifindex;
 	bool filter_cgroup;
+	bool groupby_ifindex;
 };
 
 #endif

--- a/netstacklat/netstacklat.h
+++ b/netstacklat/netstacklat.h
@@ -63,6 +63,7 @@ enum netstacklat_hook {
  * member is named "bucket" and is the histogram bucket index.
  */
 struct hist_key {
+	__u64 cgroup;
 	__u32 ifindex;
 	__u16 hook; // need well defined size for ebpf-exporter to decode
 	__u16 bucket; // needs to be last to be compatible with ebpf-exporter
@@ -75,6 +76,7 @@ struct netstacklat_bpf_config {
 	bool filter_ifindex;
 	bool filter_cgroup;
 	bool groupby_ifindex;
+	bool groupby_cgroup;
 };
 
 #endif

--- a/netstacklat/netstacklat.h
+++ b/netstacklat/netstacklat.h
@@ -15,6 +15,8 @@
 
 // The highest possible PID on a Linux system (from /include/linux/threads.h)
 #define PID_MAX_LIMIT (4 * 1024 * 1024)
+// The highest ifindex we expect to encounter
+#define IFINDEX_MAX 16384
 
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
@@ -53,6 +55,7 @@ struct hist_key {
 
 struct netstacklat_bpf_config {
 	bool filter_pid;
+	bool filter_ifindex;
 };
 
 #endif

--- a/netstacklat/netstacklat.h
+++ b/netstacklat/netstacklat.h
@@ -60,6 +60,7 @@ struct hist_key {
 
 struct netstacklat_bpf_config {
 	__u32 network_ns;
+	__u32 filter_min_sockqueue_len;
 	bool filter_pid;
 	bool filter_ifindex;
 	bool filter_cgroup;

--- a/netstacklat/netstacklat.h
+++ b/netstacklat/netstacklat.h
@@ -41,10 +41,18 @@ enum netstacklat_hook {
 	NETSTACKLAT_N_HOOKS,
 };
 
-struct netstacklat_bpf_config
-{
+/*
+ * Key used for the histogram map
+ * To be compatible with ebpf-exporter, all histograms need a key struct whose final
+ * member is named "bucket" and is the histogram bucket index.
+ */
+struct hist_key {
+	__u16 hook; // need well defined size for ebpf-exporter to decode
+	__u16 bucket; // needs to be last to be compatible with ebpf-exporter
+};
+
+struct netstacklat_bpf_config {
 	bool filter_pid;
 };
 
 #endif
-

--- a/netstacklat/netstacklat.h
+++ b/netstacklat/netstacklat.h
@@ -18,6 +18,11 @@
 // The highest ifindex we expect to encounter
 #define IFINDEX_MAX 16384
 
+// Maximum number of PIDs/ifaces/cgroups to read from the user and filter for
+#define MAX_PARSED_PIDS 4096
+#define MAX_PARSED_IFACES 4096
+#define MAX_PARSED_CGROUPS 4096
+
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
 #endif
@@ -57,6 +62,7 @@ struct netstacklat_bpf_config {
 	__u32 network_ns;
 	bool filter_pid;
 	bool filter_ifindex;
+	bool filter_cgroup;
 };
 
 #endif

--- a/netstacklat/netstacklat.h
+++ b/netstacklat/netstacklat.h
@@ -54,6 +54,7 @@ struct hist_key {
 };
 
 struct netstacklat_bpf_config {
+	__u32 network_ns;
 	bool filter_pid;
 	bool filter_ifindex;
 };

--- a/netstacklat/netstacklat.yaml
+++ b/netstacklat/netstacklat.yaml
@@ -7,6 +7,13 @@ metrics:
       bucket_max: 34
       bucket_multiplier: 0.000000001 # nanoseconds to seconds
       labels:
+        - name: iface
+          size: 4
+          decoders:
+            # If including output from a different network namespace than ebpf-exporter
+            # you probably just want to decode as a uint (ifindex) instead
+            # - name: uint # For the ifname decoder you apparently don't first need a uint decoder like the others
+            - name: ifname
         - name: hook
           size: 2
           decoders:

--- a/netstacklat/netstacklat.yaml
+++ b/netstacklat/netstacklat.yaml
@@ -7,6 +7,11 @@ metrics:
       bucket_max: 34
       bucket_multiplier: 0.000000001 # nanoseconds to seconds
       labels:
+        - name: cgroup
+          size: 8
+          decoders:
+            - name: uint
+            - name: cgroup
         - name: iface
           size: 4
           decoders:

--- a/netstacklat/netstacklat.yaml
+++ b/netstacklat/netstacklat.yaml
@@ -1,79 +1,27 @@
 metrics:
   histograms:
-    - name: netstack_latency_ip_start_seconds
-      help: Time for packet to reach the start of the IP-stack
+    - name: netstack_latency_seconds
+      help: Latency for packets (skbs) to reach various points in the kernel network stack
       bucket_type: exp2
       bucket_min: 0
       bucket_max: 34
       bucket_multiplier: 0.000000001 # nanoseconds to seconds
       labels:
-        - name: bucket
-          size: 4
+        - name: hook
+          size: 2
           decoders:
             - name: uint
-    - name: netstack_latency_tcp_start_seconds
-      help: Time for packet to reach the start of the TCP stack
-      bucket_type: exp2
-      bucket_min: 0
-      bucket_max: 34
-      bucket_multiplier: 0.000000001 # nanoseconds to seconds
-      labels:
+            - name: static_map
+              static_map:
+                1: "ip-start"
+                2: "tcp-start"
+                3: "udp-start"
+                4: "tcp-socket-enqueued"
+                5: "udp-socket-enqueued"
+                6: "tcp-socket-read"
+                7: "udp-socket-read"
         - name: bucket
-          size: 4
+          size: 2
           decoders:
             - name: uint
-    - name: netstack_latency_udp_start_seconds
-      help: Time until packet to reach the start of the UDP stack
-      bucket_type: exp2
-      bucket_min: 0
-      bucket_max: 34
-      bucket_multiplier: 0.000000001 # nanoseconds to seconds
-      labels:
-        - name: bucket
-          size: 4
-          decoders:
-            - name: uint
-    - name: netstack_latency_tcp_sock_enqueued_seconds
-      help: Time until packet is queued to TCP socket
-      bucket_type: exp2
-      bucket_min: 0
-      bucket_max: 34
-      bucket_multiplier: 0.000000001 # nanoseconds to seconds
-      labels:
-        - name: bucket
-          size: 4
-          decoders:
-            - name: uint
-    - name: netstack_latency_udp_sock_enqueued_seconds
-      help: Time until packet is queued to UDP socket
-      bucket_type: exp2
-      bucket_min: 0
-      bucket_max: 34
-      bucket_multiplier: 0.000000001 # nanoseconds to seconds
-      labels:
-        - name: bucket
-          size: 4
-          decoders:
-            - name: uint
-    - name: netstack_latency_tcp_sock_read_seconds
-      help: Time until packet data is read from TCP socket
-      bucket_type: exp2
-      bucket_min: 0
-      bucket_max: 34
-      bucket_multiplier: 0.000000001 # nanoseconds to seconds
-      labels:
-        - name: bucket
-          size: 4
-          decoders:
-            - name: uint
-    - name: netstack_latency_udp_sock_read_seconds
-      help: Time until packet data is read from UDP socket
-      bucket_type: exp2
-      bucket_min: 0
-      bucket_max: 34
-      bucket_multiplier: 0.000000001 # nanoseconds to seconds
-      labels:
-        - name: bucket
-          size: 4
-          decoders:
-            - name: uint
+

--- a/netstacklat/netstacklat.yaml
+++ b/netstacklat/netstacklat.yaml
@@ -25,3 +25,11 @@ metrics:
           decoders:
             - name: uint
 
+cgroup_id_map:
+  name: netstack_cgroupfilter
+  type: hash
+  regexps:
+    # Change this to match the cgroups you want to include.
+    # Only has an effect if user_config.filter_cgroup is true.
+    - ^.*(system.slice/.*)$
+


### PR DESCRIPTION
Hi @tohojo and @netoptimizer. This is only draft PR for now to facilitate some discussion. For a real PR I imagine we break this down into some smaller chunks (this is 4 different branches stacked on top of each other). Each of those essentially deals with:
- Change the socket enqueue hook because the one I used had some issues
- Multiplex all histograms into a single hashmap (needed for the grouping support, and is generally more convenient)
- Additional filtering options (ifindex, network namespace and cgroup. TODO: add filter for non-empty socket rx queues)
- Groupby support (ifindex and cgroups)

So I do not expect you to review this in detail as of now (although if you have nothing better to do feel free to do so, do not have any major cleanup planned). I would however like some feedback on some design decisions and the limitations they bring. The design decisions/limitations that I would like you to consider are:
- For multiplexing histograms:
  - In userspace I maintain a sorted array of the histogram keys to allow relatively fast lookup via `bsearch`. Insertion is not very efficient (O(n)), but should be manageable as long as we do not have more than few thousand histograms (will do some more performance tests).
  - If the BPF hashmap runs out of space (which may happen with the groupby options) it will simply not create any new entries. This may result in it keeping partial histograms, where some buckets are miss-reported as being empty. I do not attempt to evict any existing entry as I do not really have any good grounds to do that on. LRU could be an option, but Jesper mentioned they do not work too well with many CPUs.
  - If userspace runs out of space for histogram keys (which may happen with groupby), it will warn that it's missing some histograms collected by the eBPF programs, but keep running.

- For ifindex filtering: 
  - I do not support ifindex > 16384 (can be bumped up a bit, but not practical to support >> 1000000 (see commit message for b05cd3837 - "netstacklat: Add filtering for network interfaces")
  - I only check the ifindex, I do not jointly consider ifindex - namespace combinations (only really intend you to track one namespace, see next point)

- For network namespace filtering:
  - By default I set netstacklat to filter for the same network namespace as you run the tool in (which will probably be the root network namespace)
  - I only support filtering for a single network namespace (see message for eb291bdf - "netstacklat: Add filtering for network namespace"). However, you can disable the filtering to get data for all network namespaces.

- For groupby options:
  - You supply each groupby option as it's own command-line argument (i.e. `--groupby-interface` and `--groupby-cgroup`). It would perhaps be nicer to have `--groupby interface,cgroup`, but I find that adds needless complexity as long as we only have 2 options. For now it's unlikely I'll add many more groupby options, as the amount histograms you get for all combinations quickly explode.
  - For `--groupby-interface` the user space agent prints out the ifindex, not the interface name (see message for d42cdc20 - "netstacklat: Add option to groupby interface"). The provided ebpf-exporter config attempts to print out the interface names (but I assume that will not work as intended if the ifindex is from a different namespace).
  - For `--groupby-cgroup` the user space agent prints out the cgroup ID (inode), not the path (see message for cf7db6f593 - "netstacklat: Add option to groupby cgroup"). The provided ebpf-exporter config prints out the paths.

Further details can be found in each commit message.

@netoptimizer There's currently (AFAIK) no convenient way to provide the various values to filter for with ebpf-exporter. If [PR 531 for ebpf-exporter](https://github.com/cloudflare/ebpf_exporter/pull/531) is merged it seems like you would be able to provide a cgroup path regex in the YAML config, but that still leaves filtering on PIDs, interfaces and network namespace. The network namespace can be hardcoded in the config in the eBPF source code, but the rest need to be set in BPF maps (after their corresponding `filter_xxx` member in the config in the eBPF source has been set to true). That can be done externally with `bpftool`. Can hack up some shell script that does that if you want. 