### PR TITLE
trie-free-latency: Demo showing the latency of freeing LPM_TRIE maps

### DIFF
--- a/LPM-map-bench/.gitignore
+++ b/LPM-map-bench/.gitignore
@@ -1,0 +1,1 @@
+trie-free-latency

--- a/LPM-map-bench/Makefile
+++ b/LPM-map-bench/Makefile
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+
+USER_TARGETS   := trie-free-latency
+BPF_TARGETS    := trie-free-latency.bpf stats.bpf
+BPF_SKEL_OBJ   := trie-free-latency.bpf.o stats.bpf.o
+
+EXTRA_DEPS += trie.h
+LDLIBS     += -lm
+
+LIB_DIR = ../lib
+
+include $(LIB_DIR)/common.mk
+

--- a/LPM-map-bench/README.org
+++ b/LPM-map-bench/README.org
@@ -1,0 +1,19 @@
+* Demonstration of trie_free() latency for large maps
+
+Freeing large LPM_TRIE maps can take significant time. This demo shows the
+duration of trie_free() for trie maps with varying numbers of entries.
+
+Below are the results showing trie_free() durations when running Linux 6.12.32
+on AMD EPYC 9684X (96-Core):
+
+| Num of map entries | Duration |  CoV  | Duration per entry |
+|--------------------|----------|-------|--------------------|
+| 1K                 | 0ms      | 2.88% | 239ns              |
+| 10K                | 2ms      | 0.97% | 242ns              |
+| 100K               | 32ms     | 2.54% | 329ns              |
+| 1M                 | 427ms    | 1.17% | 427ns              |
+| 10M                | 5056ms   | 1.74% | 505ns              |
+| 100M               | 67253ms  | 1.48% | 672ns              |
+
+Clearly the algorithm doesn't scale linearly and the per entry duration at 100M
+entries is almost 3x that at 1K.

--- a/LPM-map-bench/stats.bpf.c
+++ b/LPM-map-bench/stats.bpf.c
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h> /* CO-RE */
+#include <bpf/bpf_tracing.h>
+
+#include "trie.h"
+
+char LICENSE[] SEC("license") = "GPL";
+
+struct bpf_map___local {
+	char name[BPF_OBJ_NAME_LEN];
+} __attribute__((preserve_access_index));
+
+struct lpm_trie___local {
+	struct bpf_map___local map;
+	unsigned int n_entries;
+} __attribute__((preserve_access_index));
+
+struct {
+        __uint(type, BPF_MAP_TYPE_HASH);
+        __uint(max_entries, 512);
+        __type(key, struct bpf_map___local *);
+        __type(value, struct latency_record);
+} latency_start SEC(".maps");
+
+struct {
+        __uint(type, BPF_MAP_TYPE_HASH);
+        __uint(max_entries, 512);
+        __type(key, struct bpf_map___local *);
+        __type(value, struct latency_record);
+} latencies SEC(".maps");
+
+SEC("fentry/trie_free")
+int BPF_PROG(trie_free_entry, struct bpf_map___local *map)
+{
+	char *name = BPF_CORE_READ(map, name);
+	struct latency_record r = {
+		.val = bpf_ktime_get_ns(),
+	};
+	int i;
+	struct lpm_trie___local *trie;
+
+	/*
+	 * Ideally we'd have access to the map ID but that's already
+	 * freed before we enter trie_free().
+	 */
+	for (i = 0; i < BPF_OBJ_NAME_LEN; i++) {
+		r.name[i] = name[i];
+	}
+
+	trie = container_of(map, struct lpm_trie___local, map);
+	r.n_entries = BPF_CORE_READ(trie, n_entries);
+
+	bpf_map_update_elem(&latency_start, &map, &r, BPF_ANY);
+	return 0;
+}
+
+SEC("fexit/trie_free")
+int BPF_PROG(trie_free_exit, struct bpf_map___local *map)
+{
+	struct latency_record *r;
+
+	r = bpf_map_lookup_elem(&latency_start, &map);
+	if (r) {
+		/*
+		 * Convert the record's start time into a latency result and
+		 * copy it to the latencies map.
+		 */
+		__u64 delta_ns = bpf_ktime_get_ns() - r->val;
+		r->val = delta_ns;
+
+		bpf_map_update_elem(&latencies, &map, r, BPF_ANY);
+		bpf_map_delete_elem(&latency_start, &map);
+	}
+
+        return 0;
+}

--- a/LPM-map-bench/trie-free-latency.bpf.c
+++ b/LPM-map-bench/trie-free-latency.bpf.c
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include "trie.h"
+
+struct {
+        __uint(type, BPF_MAP_TYPE_LPM_TRIE);
+        __type(key, struct trie_key);
+        __type(value, __u32);
+        __uint(map_flags, BPF_F_NO_PREALLOC);
+        __uint(max_entries, MAX_ENTRIES);
+} trie_map SEC(".maps");

--- a/LPM-map-bench/trie-free-latency.c
+++ b/LPM-map-bench/trie-free-latency.c
@@ -1,0 +1,248 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#define _GNU_SOURCE
+#include <sys/epoll.h>
+#include <getopt.h>
+#include <math.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+#include <linux/bpf.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "stats.bpf.skel.h"
+#include "trie-free-latency.bpf.skel.h"
+#include "trie.h"
+
+static unsigned int n_entries = 0;
+static unsigned int n_iterations = 0;
+
+static int fill_map(struct bpf_map *map)
+{
+	int err;
+	int i;
+
+	for (i = 0 ; i < n_entries; i++) {
+		struct trie_key key = {
+			.prefixlen = 32,
+			.data = i
+		};
+		__u32 val = 1;
+
+		err = bpf_map__update_elem(map, &key, sizeof(key), &val, sizeof(val), 0);
+		if (err) {
+			fprintf(stderr, "Error: %d for key=%d\n", err, i);
+			return err;
+		}
+	}
+	return 0;
+}
+
+
+static __u64 wait_for_free(struct trie_free_latency_bpf *skel, struct bpf_map *map)
+{
+	struct bpf_map *key = NULL, *prev = NULL;
+	struct latency_record r;
+
+	for (;;) {
+		int err = bpf_map__get_next_key(map, &prev, &key, sizeof(key));
+
+		if (-err == ENOENT) {
+			// Reached end of map. Reset.
+			prev = NULL;
+			usleep(2000);
+		} else {
+			if (bpf_map__lookup_elem(map, &key, sizeof(key),
+						&r, sizeof(r), 0) == 0) {
+				if (!strcmp(r.name, "trie_map"))
+					return r.val;
+			}
+			prev = key;
+		}
+	}
+	return -1;
+}
+
+static void usage(const char *progname)
+{
+	fprintf(stderr, "Usage: %s -e <num entries> -i <num iterations>\n", progname);
+	exit(EXIT_FAILURE);
+}
+
+static int parse_args(int argc, char **argv)
+{
+	struct option lopts[] = {
+		{ NULL, 0, 0, 0 }
+	};
+	int opt, opt_index;
+
+	for (;;) {
+		opt = getopt_long(argc, argv, "e:i:", lopts, &opt_index);
+		if (opt == EOF)
+			break;
+
+		switch (opt) {
+		case 'e':
+			n_entries = atoi(optarg);
+			break;
+		case 'i':
+			n_iterations = atoi(optarg);
+			break;
+		default:
+			usage(argv[0]);
+		}
+	}
+
+	if (n_entries == 0 && n_iterations == 0)
+		usage(argv[0]);
+
+	if (n_entries == 0) {
+		fprintf(stderr, "Error: -e argument must be greater than zero.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (n_iterations == 0) {
+		fprintf(stderr, "Error: -i argument must be greater than zero.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (n_entries > MAX_ENTRIES) {
+		fprintf(stderr, "Error: -e argument too large. Increase MAX_ENTRIES.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	return 0;
+}
+
+static int run(struct stats_bpf *stats, __u64 *latency_ns)
+{
+	struct trie_free_latency_bpf *skel;
+	int err = 0;
+
+	skel = trie_free_latency_bpf__open();
+	if (!skel)
+		goto cleanup;
+
+	err = trie_free_latency_bpf__load(skel);
+	if (err)
+		goto cleanup;
+
+	err = trie_free_latency_bpf__attach(skel);
+	if (err)
+		goto cleanup;
+
+	err = fill_map(skel->maps.trie_map);
+	if (err)
+		goto cleanup;
+
+	// Wait for map to be freed
+	trie_free_latency_bpf__destroy(skel);
+	*latency_ns = wait_for_free(skel, stats->maps.latencies);
+
+	return 0;
+
+cleanup:
+	trie_free_latency_bpf__destroy(skel);
+	return err;
+}
+
+static inline __u64 square(__u64 val)
+{
+	return val * val;
+}
+
+static inline __u64 calc_mean(__u64 *latencies)
+{
+	__u64 mean;
+	int i;
+
+	for (mean = 0, i = 0; i < n_iterations; i++) {
+		mean += latencies[i];
+	}
+
+	return mean / n_iterations;
+}
+
+static inline __u64 calc_stddev(__u64 *latencies, __u64 mean)
+{
+	__u64 stddev, *squares;
+	int i;
+
+	squares = calloc(n_iterations, sizeof(*squares));
+	if (!squares) {
+		perror("calloc");
+		exit(EXIT_FAILURE);
+	}
+
+	for (i = 0; i < n_iterations; i++) {
+		squares[i] = square(latencies[i] - mean);
+	}
+
+	for (stddev = 0, i = 0; i < n_iterations; i++) {
+		stddev += squares[i];
+	}
+
+	free(squares);
+
+	if (!stddev)
+		return 0;
+
+	return sqrt(stddev / (n_iterations - 1));
+}
+
+
+static void print_stats(__u64 *latencies)
+{
+	__u64 mean, stddev;
+	double cov;
+
+	mean = calc_mean(latencies);
+	stddev = calc_stddev(latencies, mean);
+	cov = (double)(100 * stddev) / mean;
+
+	printf("Average time to free %u entries is %llums (±%.2f%%) "
+			"(%lluns per entry)\n", n_entries,
+			mean / 1000000, cov, mean / n_entries);
+}
+
+int main(int argc, char **argv)
+{
+	struct stats_bpf *stats;
+	__u64 *latencies = NULL;
+	int i, err;
+
+	err = parse_args(argc, argv);
+	if (err)
+		usage(argv[0]);
+
+	stats = stats_bpf__open();
+	if (!stats)
+		goto cleanup;
+
+	err = stats_bpf__load(stats);
+	if (err)
+		goto cleanup;
+
+	err = stats_bpf__attach(stats);
+	if (err)
+		goto cleanup;
+
+	latencies = calloc(n_iterations, sizeof(*latencies));
+	if (!latencies) {
+		perror("calloc");
+		err = EXIT_FAILURE;
+		goto cleanup;
+	}
+
+	for (i = 0; i < n_iterations; i++) {
+		err = run(stats, &latencies[i]);
+		if (err)
+			goto cleanup;
+	}
+
+	print_stats(latencies);
+
+cleanup:
+	free(latencies);
+	stats_bpf__destroy(stats);
+	return err;
+}

--- a/LPM-map-bench/trie.h
+++ b/LPM-map-bench/trie.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef TRIE_H
+#define TRIE_H
+
+#define MAX_ENTRIES 100000000 // 100 million
+
+struct trie_key {
+        __u32 prefixlen;
+        __u32 data;
+};
+
+struct latency_record {
+	// map name
+	char name[BPF_OBJ_NAME_LEN];
+	// number of entries in map
+	unsigned int n_entries;
+	// duration (ns) of trie_free()
+	__u64 val;
+};
+
+#endif


### PR DESCRIPTION
The performance of freeing LPM_TRIE maps suffers heavily for maps with a large number of entries. Here's a little demo that measures the duration of trie_free() and allows the user to control how many entries are in the map, as well as how many iterations of the demo are run to collect latency statistics.

This is a reproduction of an issue we've seen at Cloudflare and a public demo to aid with the upstream discussion at https://lore.kernel.org/lkml/20250616095532.47020-1-matt@readmodwrite.com/