### PR TITLE
fix(xdpsock): correct long option for frag support (--frags)

### DIFF
--- a/AF_XDP-example/xdpsock.c
+++ b/AF_XDP-example/xdpsock.c
@@ -1098,7 +1098,7 @@ static struct option long_options[] = {
 	{"no-need-wakeup", no_argument, 0, 'm'},
 	{"unaligned", no_argument, 0, 'u'},
 	{"shared-umem", no_argument, 0, 'M'},
-	{"force", no_argument, 0, 'F'},
+	{"frags", no_argument, 0, 'F'},
 	{"duration", required_argument, 0, 'd'},
 	{"clock", required_argument, 0, 'w'},
 	{"batch-size", required_argument, 0, 'b'},


### PR DESCRIPTION
The xdpsock tool currently documents a --frags option, but only the short -F flag was actually supported by the option parser. This caused a mismatch between the advertised CLI usage and the actual behavior.

Fix this by adding the missing --frags long option, making the CLI consistent and preventing user confusion.