### PR TITLE
traffic-pacing-edt: document the two-tag (QinQ) VLAN assumption

### DIFF
--- a/traffic-pacing-edt/edt_pacer_vlan.c
+++ b/traffic-pacing-edt/edt_pacer_vlan.c
@@ -219,6 +219,16 @@ __u16 get_vlan(struct __sk_buff *skb, struct collect_vlans *vlans)
 	return vlan_key;
 }
 
+/* The pacing key is one VLAN taken from at most depth 1
+ * (VLAN_MAX_DEPTH=2), chosen as id[0] or id[1] depending on whether
+ * the NIC offloaded the outer VLAN. Same two-tag (QinQ) edge
+ * assumption as xdp_cpumap_qinq.c: a frame carrying three or more
+ * tags is still processed, but the tag at depth 2 is not collected,
+ * so the key falls back to a tag at depth 0 or 1 instead of the true
+ * inner tag. Reject beyond depth 2 upstream if untrusted producers
+ * can prepend tags, or raise VLAN_MAX_DEPTH if a deeper inner tag is
+ * needed.
+ */
 static __always_inline
 __u16 extract_vlan_key(struct __sk_buff *skb, struct collect_vlans *vlans)
 {

--- a/traffic-pacing-edt/xdp_cpumap_qinq.c
+++ b/traffic-pacing-edt/xdp_cpumap_qinq.c
@@ -41,6 +41,14 @@ struct {
 	__uint(max_entries, 1);
 } cpus_count SEC(".maps");
 
+/* The CPU-steering key combines vlans->id[0] and id[1] only
+ * (VLAN_MAX_DEPTH=2 above). This example assumes a two-tag (QinQ)
+ * edge: a frame carrying three or more VLAN tags is processed and
+ * keyed on its first two tags, so it lands in the same CPU bucket as
+ * the legitimate (id[0], id[1]) frame. If untrusted producers can
+ * prepend tags, reject beyond depth 2 before this program or raise
+ * VLAN_MAX_DEPTH and rework the key to cover the additional tags.
+ */
 static __always_inline
 __u32 extract_vlan_key(struct collect_vlans *vlans)
 {


### PR DESCRIPTION
`xdp_cpumap_qinq.c` and `edt_pacer_vlan.c` both define
`VLAN_MAX_DEPTH=2` for `parsing_helpers` and key on
`vlans->id[0]`/`id[1]` only. A frame with three or more VLAN tags is
still processed but the tag at depth 2 is not collected, so it
collides with the matching two-tag frame in the steering example and
selects the wrong tag as the pacing key in the pacer.

This is the intended example assumption (two-tag QinQ edge). Add a
comment near each `extract_vlan_key()` spelling out the assumption
and the two ways to lift it (reject beyond depth 2 upstream, or
raise `VLAN_MAX_DEPTH` and rework the key) so anyone adapting the
example to deployments that accept untrusted tagged input notices.

Docs-only, no behaviour change.
