### PR TITLE
pping: add json-lines (jsonl) output format

### DIFF
--- a/lib/util/json_writer.c
+++ b/lib/util/json_writer.c
@@ -25,6 +25,7 @@ struct json_writer {
 	FILE		*out;	/* output file */
 	unsigned	depth;  /* nesting */
 	bool		pretty; /* optional whitepace */
+	bool		line_delimited; /* json-lines mode */
 	char		sep;	/* either nul or comma */
 };
 
@@ -100,6 +101,7 @@ json_writer_t *jsonw_new(FILE *f)
 		self->out = f;
 		self->depth = 0;
 		self->pretty = false;
+		self->line_delimited = false;
 		self->sep = '\0';
 	}
 	return self;
@@ -120,6 +122,15 @@ void jsonw_destroy(json_writer_t **self_p)
 void jsonw_pretty(json_writer_t *self, bool on)
 {
 	self->pretty = on;
+	if (on)
+		self->line_delimited = false;
+}
+
+void jsonw_line_delimited(json_writer_t *self, bool on)
+{
+	self->line_delimited = on;
+	if (on)
+		self->pretty = false;
 }
 
 /* Basic blocks */
@@ -139,7 +150,14 @@ static void jsonw_end(json_writer_t *self, int c)
 	if (self->sep != '\0')
 		jsonw_eol(self);
 	putc(c, self->out);
-	self->sep = ',';
+	if (self->line_delimited && self->depth == 0) {
+		/* Terminate each top-level object with a trailing newline */
+		putc('\n', self->out);
+		fflush(self->out);
+		self->sep = '\0';
+	} else {
+		self->sep = ',';
+	}
 }
 
 

--- a/lib/util/json_writer.h
+++ b/lib/util/json_writer.h
@@ -28,6 +28,9 @@ void jsonw_destroy(json_writer_t **self_p);
 /* Cause output to have pretty whitespace */
 void jsonw_pretty(json_writer_t *self, bool on);
 
+/* Emit top-level objects as newline-delimited JSON (json-lines), no array */
+void jsonw_line_delimited(json_writer_t *self, bool on);
+
 /* Add property name */
 void jsonw_name(json_writer_t *self, const char *name);
 

--- a/pping/README.md
+++ b/pping/README.md
@@ -37,7 +37,7 @@ echo identifer, and thus all instaces of ping originating from a particular
 Windows host and the same target host will be considered a single flow.
 
 ## Output formats
-pping currently supports 3 different formats, *standard*, *ppviz* and *json*. In
+pping currently supports 4 different formats, *standard*, *ppviz*, *json* and *jsonl*. In
 general, the output consists of two different types of events, flow-events which
 gives information that a flow has started/ended, and RTT-events which provides
 information on a computed RTT within a flow.
@@ -118,6 +118,24 @@ An example of a (pretty-printed) RTT-even is provided below:
     "rec_bytes": 37,
     "match_on_egress": false
 }
+```
+
+### JSON Lines format
+The JSON Lines (`jsonl`) format contains the same per-event objects as the JSON
+format, but emits them as a [JSON Lines](https://jsonlines.org/) stream: one
+JSON object per line, with no enclosing array. The JSON format wraps all events
+in a single root-level array, which can only be parsed once that array is closed
+and which produces invalid (concatenated) arrays if the output is appended to
+across several runs. The jsonl format instead produces an append-only log that
+can be read line by line and stays valid as it grows, which is convenient for
+streaming the output into a file or processing it with line-oriented tools (each
+line is independently valid JSON).
+
+The objects and their fields are identical to the [JSON format](#json-format);
+only the framing differs. An example flow-event (a single line, wrapped here for
+readability) is:
+```json
+{"timestamp":1623420837244545000,"src_ip":"10.11.1.1","src_port":5201,"dest_ip":"10.11.1.2","dest_port":59572,"protocol":"TCP","flow_event":"opening","reason":"SYN-ACK","triggered_by":"dest"}
 ```
 
 ## Design and technical description

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -73,6 +73,7 @@ static const char *__doc__ =
 enum pping_output_format {
 	PPING_OUTPUT_STANDARD,
 	PPING_OUTPUT_JSON,
+	PPING_OUTPUT_JSONL,
 	PPING_OUTPUT_PPVIZ
 };
 
@@ -167,7 +168,7 @@ static const struct option long_options[] = {
 	{ "rtt-type",             required_argument, NULL, 't' }, // What type of RTT the RTT-rate should be applied to ("min" or "smoothed"), only relevant if rtt-rate is provided
 	{ "force",                no_argument,       NULL, 'f' }, // Overwrite any existing XDP program on interface, remove qdisc on cleanup
 	{ "cleanup-interval",     required_argument, NULL, 'c' }, // Map cleaning interval in s, 0 to disable
-	{ "format",               required_argument, NULL, 'F' }, // Which format to output in (standard/json/ppviz)
+	{ "format",               required_argument, NULL, 'F' }, // Which format to output in (standard/json/jsonl/ppviz)
 	{ "ingress-hook",         required_argument, NULL, 'I' }, // Use tc or XDP as ingress hook
 	{ "xdp-mode",             required_argument, NULL, 'x' }, // Which xdp-mode to use (unspecified, native or generic)
 	{ "tcp",                  no_argument,       NULL, 'T' }, // Calculate and report RTTs for TCP traffic (with TCP timestamps)
@@ -354,11 +355,13 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 				config->format = PPING_OUTPUT_STANDARD;
 			} else if (strcmp(optarg, "json") == 0) {
 				config->format = PPING_OUTPUT_JSON;
+			} else if (strcmp(optarg, "jsonl") == 0) {
+				config->format = PPING_OUTPUT_JSONL;
 			} else if (strcmp(optarg, "ppviz") == 0) {
 				config->format = PPING_OUTPUT_PPVIZ;
 			} else {
 				fprintf(stderr,
-					"format must be \"standard\", \"json\" or \"ppviz\"\n");
+					"format must be \"standard\", \"json\", \"jsonl\" or \"ppviz\"\n");
 				return -EINVAL;
 			}
 			break;
@@ -490,6 +493,8 @@ const char *output_format_to_str(enum pping_output_format format)
 		return "standard";
 	case PPING_OUTPUT_JSON:
 		return "json";
+	case PPING_OUTPUT_JSONL:
+		return "jsonl";
 	case PPING_OUTPUT_PPVIZ:
 		return "ppviz";
 	default:
@@ -1084,6 +1089,7 @@ static void print_event(struct output_context *out_ctx,
 		print_event_standard(out_ctx->stream, pe);
 		break;
 	case PPING_OUTPUT_JSON:
+	case PPING_OUTPUT_JSONL:
 		if (out_ctx->jctx)
 			print_event_json(out_ctx->jctx, pe);
 		break;
@@ -2106,11 +2112,15 @@ static struct output_context *open_output(const char *filename,
 		out_ctx->stream = stdout;
 	}
 
-	if (out_ctx->format == PPING_OUTPUT_JSON) {
+	if (out_ctx->format == PPING_OUTPUT_JSON ||
+	    out_ctx->format == PPING_OUTPUT_JSONL) {
 		out_ctx->jctx = jsonw_new(out_ctx->stream);
 		if (!out_ctx->jctx)
 			goto err;
-		jsonw_start_array(out_ctx->jctx);
+		if (out_ctx->format == PPING_OUTPUT_JSONL)
+			jsonw_line_delimited(out_ctx->jctx, true);
+		else
+			jsonw_start_array(out_ctx->jctx);
 	}
 
 	if (agg_conf)
@@ -2127,7 +2137,8 @@ static int close_output(struct output_context *out_ctx)
 	int err = 0;
 
 	if (out_ctx->jctx) {
-		jsonw_end_array(out_ctx->jctx);
+		if (out_ctx->format == PPING_OUTPUT_JSON)
+			jsonw_end_array(out_ctx->jctx);
 		jsonw_destroy(&out_ctx->jctx);
 	}
 


### PR DESCRIPTION
Adds `--format jsonl`: one JSON object per line with no enclosing array, so the output is an append-only log that can be tailed/streamed and stays valid as it grows. The existing `json` format wraps everything in a single root array that is only parseable once the process closes it, and concatenates into invalid JSON if the output is appended across restarts. Same per-event objects and fields as `json`; the `json` format itself is unchanged.

- Commit 1 adds the format — a `line_delimited` mode on the json_writer — plus README and `--format` help.
- Commit 2 line-buffers the stream so each event is flushed as it is written.

Tested against live TCP traffic (IPv4 and IPv6); each emitted line validates as standalone JSON with `jq`.
