### PR TITLE
pping: support PPP/PPPoE and other L3 interfaces (no Ethernet header)

### DIFF
--- a/pping/README.md
+++ b/pping/README.md
@@ -12,6 +12,10 @@ could be extended to also work with for example TCP seq/ACK numbers, the QUIC
 spinbit and DNS queries. See the [TODO-list](./TODO.md) for more potential
 features (which may or may not ever get implemented).
 
+pping parses each packet starting from its Ethernet header. Interfaces that
+carry no Ethernet header -- PPP/PPPoE uplinks, tun, and other L3 interfaces --
+are detected automatically and parsed from the IP header instead.
+
 The fundamental logic of pping is to timestamp a pseudo-unique identifier for
 packets, and then look for matches in the reply packets. If a match is found,
 the RTT is simply calculated as the time difference between the current time and

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -6,6 +6,10 @@ static const char *__doc__ =
 #include <bpf/libbpf.h>
 #include <linux/if_link.h>
 #include <net/if.h> // For if_nametoindex
+#include <net/if_arp.h> // For ARPHRD_PPP/ARPHRD_NONE (detecting L3 interfaces)
+#include <sys/ioctl.h> // For ioctl()
+#include <linux/sockios.h> // For SIOCGIFHWADDR
+#include <sys/socket.h> // For socket()
 #include <arpa/inet.h> // For inet_ntoa and ntohs
 
 #include <stdio.h>
@@ -273,6 +277,35 @@ static int parse_bounded_long(long long *res, const char *str, long long low,
 	return 0;
 }
 
+/*
+ * Interfaces such as PPP/PPPoE and tun carry no Ethernet header: at the
+ * tc/XDP hook the packet starts at the IP header. Detect them via their ARP
+ * hardware type so the BPF programs skip Ethernet parsing.
+ */
+static bool iface_is_l3(const char *ifname)
+{
+	struct ifreq ifr = { 0 };
+	int fd, ret;
+
+	fd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (fd < 0)
+		return false;
+
+	memcpy(ifr.ifr_name, ifname, strlen(ifname) + 1);
+	ret = ioctl(fd, SIOCGIFHWADDR, &ifr);
+	close(fd);
+	if (ret < 0)
+		return false;
+
+	switch (ifr.ifr_hwaddr.sa_family) {
+	case ARPHRD_PPP:
+	case ARPHRD_NONE:
+		return true;
+	default:
+		return false;
+	}
+}
+
 static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 {
 	int err, opt, len;
@@ -289,6 +322,7 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 	config->bpf_config.push_individual_events = true;
 	config->bpf_config.agg_rtts = false;
 	config->bpf_config.agg_by_dst = false;
+	config->bpf_config.eth_header = true;
 
 	while ((opt = getopt_long(argc, argv, "hflTCsi:r:R:t:c:F:I:x:a:4:6:w:",
 				  long_options, NULL)) != -1) {
@@ -311,6 +345,9 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 					get_libbpf_strerror(err));
 				return err;
 			}
+
+			if (iface_is_l3(config->ifname))
+				config->bpf_config.eth_header = false;
 			break;
 		case 'r':
 			err = parse_bounded_double(&user_float, optarg, 0,
@@ -2626,9 +2663,10 @@ int main(int argc, char *argv[])
 				"Warning: ppviz format mainly intended for TCP traffic, but may now include ICMP traffic as well\n");
 	}
 
-	fprintf(stderr, "Starting ePPing in %s mode tracking %s on %s\n",
+	fprintf(stderr, "Starting ePPing in %s mode tracking %s on %s (%s header mode)\n",
 		output_format_to_str(config.format),
-		tracked_protocols_to_str(&config), config.ifname);
+		tracked_protocols_to_str(&config), config.ifname,
+		config.bpf_config.eth_header ? "Ethernet" : "IP");
 
 	config.out_ctx = open_output(
 		config.write_to_file ? config.filename : NULL, config.format,

--- a/pping/pping.h
+++ b/pping/pping.h
@@ -102,6 +102,7 @@ struct bpf_config {
 	bool push_individual_events;
 	bool agg_rtts;
 	bool agg_by_dst; // dst of reply packet
+	bool eth_header; // false for L3 ifaces (PPP/PPPoE, tun)
 };
 
 struct ipprefix_key {

--- a/pping/pping_kern.c
+++ b/pping/pping_kern.c
@@ -617,6 +617,27 @@ static int parse_icmp_identifier(struct parsing_context *pctx,
 }
 
 /*
+ * For L3 interfaces without an Ethernet header (PPP/PPPoE, tun), the packet
+ * starts at the IP header. Determine IPv4/IPv6 from the version nibble without
+ * advancing nh, so the existing parse_iphdr/parse_ip6hdr run unchanged.
+ */
+static __always_inline int parse_l3_proto(struct hdr_cursor *nh, void *data_end)
+{
+	__u8 *ipver = nh->pos;
+
+	if (ipver + 1 > data_end)
+		return -1;
+	switch (*ipver >> 4) {
+	case 4:
+		return bpf_htons(ETH_P_IP);
+	case 6:
+		return bpf_htons(ETH_P_IPV6);
+	default:
+		return -1;
+	}
+}
+
+/*
  * Attempts to parse the packet defined by pctx for a valid packet identifier
  * and reply identifier, filling in p_info.
  *
@@ -649,7 +670,10 @@ static int parse_packet_identifier(struct parsing_context *pctx,
 	__builtin_memset(p_info, 0, sizeof(*p_info));
 	p_info->time = bpf_ktime_get_ns();
 	p_info->pkt_len = pctx->pkt_len;
-	proto = parse_ethhdr(&pctx->nh, pctx->data_end, &eth);
+	if (config.eth_header)
+		proto = parse_ethhdr(&pctx->nh, pctx->data_end, &eth);
+	else
+		proto = parse_l3_proto(&pctx->nh, pctx->data_end);
 
 	// Parse IPv4/6 header
 	if (proto == bpf_htons(ETH_P_IP)) {


### PR DESCRIPTION
pping is exactly the tool I wanted, but I couldn't use it: my ISP uplink is PPPoE, which carries no Ethernet header, so pping produced no RTTs on it. This change makes it work on L3 interfaces like that.

The BPF parser assumed an Ethernet header on every packet, so on `ARPHRD_PPP`/`ARPHRD_NONE` interfaces (PPP/PPPoE uplinks, tun, and similar) it consumed 14 bytes of the IP header and dropped every packet as non-IP, so no RTT was produced.

- `parse_l3_proto()` reads the IP version nibble to pick IPv4/IPv6 without advancing the cursor, so the existing `parse_iphdr`/`parse_ip6hdr` run unchanged.
- L3 interfaces are auto-detected via `SIOCGIFHWADDR` (`ARPHRD_PPP`/`NONE`); `--eth-header`/`--ip-header` override the detection.

Tested on a live 3-uplink PPPoE router: all three links autodetect as L3 and produce TCP RTTs in jsonl.

A few things I'd appreciate your take on:

1. **Are the override flags worth keeping?** With `SIOCGIFHWADDR` autodetection they are only an escape hatch -- `--ip-header` could force L3 for a link type we don't recognise, but `--eth-header` is fairly theoretical (nothing realistic forces an Ethernet header over an `ARPHRD_PPP`/`NONE` detection). Happy to drop one or both and just trust the autodetect.
2. **`--eth-header`/`--ip-header` are long-only** (option codes >= 128, kept under 256 so `print_usage()`'s `isalnum()` stays valid). I did this so the flags are self-contained: dropping them touches only the enum, two `long_options` rows, and two `switch` cases -- nothing in the getopt short-string -- which makes their cost easy to see. If we keep them I can add short options.
3. If the overrides stay, I'll follow up to make `--eth-header`/`--ip-header` mutually exclusive (today both can be passed and the last wins) and to have an explicit flag take precedence over the autodetect regardless of argument order.
