### PR TITLE
pping: don't re-create the shared clsact qdisc for the egress hook

### DIFF
--- a/pping/pping.c
+++ b/pping/pping.c
@@ -601,8 +601,12 @@ static int xdp_detach(struct xdp_program *prog, int ifindex,
 }
 
 /*
- * Will attempt to attach program at section sec in obj to ifindex at
- * attach_point.
+ * Will attach program prog_name in obj to ifindex at attach_point.
+ * The ingress and egress programs share a single clsact qdisc (it carries both
+ * hook points), so only the first attach for an interface should create it:
+ * pass create_hook=true for that one and false for the other. This avoids
+ * re-issuing a create for the already-existing qdisc, which the kernel rejects
+ * with -EEXIST and libbpf logs as "Exclusivity flag on, cannot modify".
  * On success, will fill in the passed opts, optionally set new_hook depending
  * if it created a new hook or not, and return the id of the attached program.
  * On failure it will return a negative error code.
@@ -610,19 +614,23 @@ static int xdp_detach(struct xdp_program *prog, int ifindex,
 static int tc_attach(struct bpf_object *obj, int ifindex,
 		     enum bpf_tc_attach_point attach_point,
 		     const char *prog_name, struct bpf_tc_opts *opts,
-		     bool *new_hook)
+		     bool create_hook, bool *new_hook)
 {
 	int err;
 	int prog_fd;
-	bool created_hook = true;
+	bool created_hook = false;
 	DECLARE_LIBBPF_OPTS(bpf_tc_hook, hook, .ifindex = ifindex,
 			    .attach_point = attach_point);
 
-	err = bpf_tc_hook_create(&hook);
-	if (err == -EEXIST)
-		created_hook = false;
-	else if (err)
-		return err;
+	if (create_hook) {
+		err = bpf_tc_hook_create(&hook);
+		if (err == -EEXIST)
+			created_hook = false;
+		else if (err)
+			return err;
+		else
+			created_hook = true;
+	}
 
 	prog_fd = bpf_program__fd(
 		bpf_object__find_program_by_name(obj, prog_name));
@@ -2019,7 +2027,7 @@ static int load_attach_bpfprogs(struct bpf_object **obj,
 		}
 		err = tc_attach(*obj, config->ifindex, BPF_TC_INGRESS,
 				config->ingress_prog, &config->tc_ingress_opts,
-				&config->created_tc_hook);
+				true, &config->created_tc_hook);
 		config->ingress_prog_id = err;
 	}
 	if (err < 0) {
@@ -2029,10 +2037,11 @@ static int load_attach_bpfprogs(struct bpf_object **obj,
 		goto ingress_err;
 	}
 
-	// Attach egress prog
+	// Attach egress prog; create the clsact only when ingress used XDP
 	config->egress_prog_id = tc_attach(
 		*obj, config->ifindex, BPF_TC_EGRESS, config->egress_prog,
 		&config->tc_egress_opts,
+		strcmp(config->ingress_prog, PROG_INGRESS_XDP) == 0,
 		config->created_tc_hook ? NULL : &config->created_tc_hook);
 	if (config->egress_prog_id < 0) {
 		fprintf(stderr,

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -160,7 +160,6 @@ struct pping_config {
 	enum pping_output_format format;
 	enum xdp_attach_mode xdp_mode;
 	bool write_to_file;
-	bool force;
 	bool created_tc_hook;
 };
 
@@ -170,7 +169,7 @@ static const struct option long_options[] = {
 	{ "rate-limit",           required_argument, NULL, 'r' }, // Sampling rate-limit in ms
 	{ "rtt-rate",             required_argument, NULL, 'R' }, // Sampling rate in terms of flow-RTT (ex 1 sample per RTT-interval)
 	{ "rtt-type",             required_argument, NULL, 't' }, // What type of RTT the RTT-rate should be applied to ("min" or "smoothed"), only relevant if rtt-rate is provided
-	{ "force",                no_argument,       NULL, 'f' }, // Overwrite any existing XDP program on interface
+	{ "force",                no_argument,       NULL, 'f' }, // Deprecated, has no effect
 	{ "cleanup-interval",     required_argument, NULL, 'c' }, // Map cleaning interval in s, 0 to disable
 	{ "format",               required_argument, NULL, 'F' }, // Which format to output in (standard/json/jsonl/ppviz)
 	{ "ingress-hook",         required_argument, NULL, 'I' }, // Use tc or XDP as ingress hook
@@ -313,7 +312,6 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 	long long user_int;
 
 	config->ifindex = 0;
-	config->force = false;
 
 	config->bpf_config.localfilt = true;
 	config->bpf_config.track_tcp = false;
@@ -417,7 +415,8 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 			config->bpf_config.localfilt = false;
 			break;
 		case 'f':
-			config->force = true;
+			fprintf(stderr,
+				"Warning: --force is deprecated and has no effect\n");
 			break;
 		case 'T':
 			config->bpf_config.track_tcp = true;

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -170,7 +170,7 @@ static const struct option long_options[] = {
 	{ "rate-limit",           required_argument, NULL, 'r' }, // Sampling rate-limit in ms
 	{ "rtt-rate",             required_argument, NULL, 'R' }, // Sampling rate in terms of flow-RTT (ex 1 sample per RTT-interval)
 	{ "rtt-type",             required_argument, NULL, 't' }, // What type of RTT the RTT-rate should be applied to ("min" or "smoothed"), only relevant if rtt-rate is provided
-	{ "force",                no_argument,       NULL, 'f' }, // Overwrite any existing XDP program on interface, remove qdisc on cleanup
+	{ "force",                no_argument,       NULL, 'f' }, // Overwrite any existing XDP program on interface
 	{ "cleanup-interval",     required_argument, NULL, 'c' }, // Map cleaning interval in s, 0 to disable
 	{ "format",               required_argument, NULL, 'F' }, // Which format to output in (standard/json/jsonl/ppviz)
 	{ "ingress-hook",         required_argument, NULL, 'I' }, // Use tc or XDP as ingress hook
@@ -2793,9 +2793,13 @@ cleanup_attached_progs:
 			"Failed removing ingress program from interface %s: %s\n",
 			config.ifname, get_libbpf_strerror(detach_err));
 
+	/*
+	 * Remove the shared clsact qdisc if we created it, so it does not
+	 * linger and make the next run's create fail with -EEXIST.
+	 */
 	detach_err =
 		tc_detach(config.ifindex, BPF_TC_EGRESS, &config.tc_egress_opts,
-			  config.force && config.created_tc_hook);
+			  config.created_tc_hook);
 	if (detach_err)
 		fprintf(stderr,
 			"Failed removing egress program from interface %s: %s\n",


### PR DESCRIPTION
On startup `pping` prints:

```
libbpf: Kernel error message: Exclusivity flag on, cannot modify
```

This is confusing as a user: is it bad? is something not working? did I do something wrong? do I need to act on it, and how? I spent a while tracking it down. It turns out to be harmless, but that isn't obvious to a newcomer, so I tried to fix it.

It's also mentioned in passing in [#86](https://github.com/xdp-project/bpf-examples/issues/86#issuecomment-1549936336), where @simosund lists this message among the "harmless error messages" that are "maybe not ideal".

In tc mode the ingress and egress programs share one clsact qdisc, but each `tc_attach()` issued its own `bpf_tc_hook_create()`. The second (egress) create hits the existing qdisc, which the kernel rejects with `-EEXIST` and libbpf logs as `Exclusivity flag on, cannot modify` on every startup. The `-EEXIST` is already tolerated, but the redundant create still runs and produces the log.

`tc_attach()` now takes a `create_hook` argument, so only the first attach for an interface creates the qdisc (ingress in tc mode, or egress when ingress used XDP). The other attach uses the existing hook.

Tested on a live PPPoE router in tc-ingress mode: the `Exclusivity flag on` line is gone from startup, RTT collection unaffected.
