### PR TITLE
pping: fix errors in README, TODO and SAMPLING_DESIGN

### DIFF
--- a/pping/README.md
+++ b/pping/README.md
@@ -1,7 +1,7 @@
 # PPing using XDP and TC-BPF
 A re-implementation of [Kathie Nichols' passive ping
-(pping)](https://github.com/pollere/pping) utility using XDP (on ingress) and
-TC-BPF (on egress) for the packet capture logic.
+(pping)](https://github.com/pollere/pping) utility using XDP or TC-BPF (on
+ingress) and TC-BPF (on egress) for the packet capture logic.
 
 ## Simple description
 Passive Ping (PPing) is a simple tool for passively measuring per-flow RTTs. It
@@ -22,11 +22,11 @@ the RTT is simply calculated as the time difference between the current time and
 the stored timestamp.
 
 This tool, just as Kathie's original pping implementation, uses TCP timestamps
-as identifiers for TCP traffic. The TSval (which is a timestamp in and off
+as identifiers for TCP traffic. The TSval (which is a timestamp in and of
 itself) is used as an identifier and timestamped. Reply packets in the reverse
 flow are then parsed for the TSecr, which are the echoed TSval values from the
 receiver. The TCP timestamps are not necessarily unique for every packet (they
-have a limited update frequency, appears to be 1000 Hz for modern Linux
+have a limited update frequency, which appears to be 1000 Hz for modern Linux
 systems), so only the first instance of an identifier is timestamped, and
 matched against the first incoming packet with a matching reply identifier. The
 mechanism to ensure only the first packet is timestamped and matched differs
@@ -34,20 +34,20 @@ from the one in Kathie's pping, and is further described in
 [SAMPLING_DESIGN](./SAMPLING_DESIGN.md).
 
 For ICMP echo, it uses the echo identifier as port numbers, and echo sequence
-number as identifer to match against. Linux systems will typically use different
-echo identifers for different instances of ping, and thus each ping instance
-will be recongnized as a separate flow. Windows systems typically use a static
-echo identifer, and thus all instaces of ping originating from a particular
+number as identifier to match against. Linux systems will typically use different
+echo identifiers for different instances of ping, and thus each ping instance
+will be recognized as a separate flow. Windows systems typically use a static
+echo identifier, and thus all instances of ping originating from a particular
 Windows host and the same target host will be considered a single flow.
 
 ## Output formats
 pping currently supports 4 different formats, *standard*, *ppviz*, *json* and *jsonl*. In
 general, the output consists of two different types of events, flow-events which
-gives information that a flow has started/ended, and RTT-events which provides
+give information that a flow has started/ended, and RTT-events which provide
 information on a computed RTT within a flow.
 
 ### Standard format
-The standard format is quite similar to the Kathie's pping default output, and
+The standard format is quite similar to Kathie's pping default output, and
 is generally intended to be an easily understood human-readable format writing a
 single line per event.
 
@@ -69,7 +69,7 @@ is further described [here](http://www.pollere.net/ppviz.html).
 
 Note that the optional *FBytes*, *DBytes* and *PBytes* from the format
 specification have not been included here, and do not appear to be used by
-ppviz. Furthermore, flow events are not included in the output, as the those are
+ppviz. Furthermore, flow events are not included in the output, as those are
 not used by ppviz.
 
 An example of the format is provided below:
@@ -85,9 +85,9 @@ The JSON format is primarily intended to be machine-readable, and thus uses no
 spacing or newlines between entries to reduce the overhead. External tools such
 as [jq](https://stedolan.github.io/jq/) can be used to pretty-print the format.
 
-The format consists of an array at the root-level, and each flow or RTT even is
+The format consists of an array at the root-level, and each flow or RTT event is
 added as an object to the root-array. The events contain some additional fields
-in the JSON format which is not displayed by the other formats. All times
+in the JSON format which are not displayed by the other formats. All times
 (*timestamp*, *rtt* and *min_rtt*) are provided as integers in nanoseconds.
 
 An example of a (pretty-printed) flow-event is provided below:
@@ -105,7 +105,7 @@ An example of a (pretty-printed) flow-event is provided below:
 }
 ```
 
-An example of a (pretty-printed) RTT-even is provided below:
+An example of a (pretty-printed) RTT-event is provided below:
 ```json
 {
     "timestamp": 1623420838254558500,
@@ -143,7 +143,7 @@ readability) is:
 ```
 
 ## Design and technical description
-!["Design of eBPF pping](./eBPF_pping_design.png)
+![Design of eBPF pping](./eBPF_pping_design.png)
 
 ### Files:
 - **pping.c:** Userspace program that loads and attaches the BPF programs, pulls
@@ -160,7 +160,7 @@ readability) is:
   timestamped one in the reverse flow. If a match is found, an RTT is calculated
   and an RTT-event is pushed to userspace through the perf-buffer `events`. For
   each packet with a valid identifier, the program also keeps track of and
-  updates the state flow and reverse flow, stored in the `flow_state` map.
+  updates the state of the flow and reverse flow, stored in the `flow_state` map.
 - **pping.h:** Common header file included by `pping.c` and
   `pping_kern.c`. Contains some common structs used by both (are part of the
   maps).
@@ -175,7 +175,7 @@ readability) is:
   is found, and removed if a match is found. Leftover entries are eventually
   removed by userspace (`pping.c`).
 - **events:** A perf-buffer used by the BPF programs to push flow or RTT events
-  to `pping.c`, which continuously polls the map the prints them out.
+  to `pping.c`, which continuously polls the map and prints them out.
 
 
 ## Similar projects
@@ -186,7 +186,7 @@ RTT calculation using TCP timestamps (as in this project) works is provided in
 
 - [pping](https://github.com/pollere/pping): This project is largely a
   re-implementation of Kathie's pping, but by using BPF and XDP as well as
-  implementing some filtering logic the hope is to be able to create a always-on
+  implementing some filtering logic the hope is to be able to create an always-on
   tool that can scale well even to large amounts of massive flows.
 - [ppviz](https://github.com/pollere/ppviz): Web-based visualization tool for
   the "machine-friendly" (-m) output from Kathie's pping tool. Running this

--- a/pping/SAMPLING_DESIGN.md
+++ b/pping/SAMPLING_DESIGN.md
@@ -16,7 +16,7 @@ therefore only used on egress to determine if a timestamp entry should
 be created for a packet. All packets on ingress will still be parsed
 and checked for a potential match.
 
-A secondary purpose of the sampling is the reduce the amount of output
+A secondary purpose of the sampling is to reduce the amount of output
 that pping creates. In most circumstances, getting 1000 RTT reports
 per second from a single flow will probably not be of interest, making
 it less useful as a direct command-line utility.
@@ -44,7 +44,7 @@ performed, ex:
     these approaches. Would take considerable research from my side
     to figure out how these methods work, how to best apply it to
     pping, and how to implement it in BPF.
-- Used time-based sampling, limiting the rate of how often entries
+- Use time-based sampling, limiting the rate of how often entries
   can be created per flow
   - Intuitively simple
   - Should correspond quite well with the output you would probably
@@ -68,7 +68,7 @@ would get (per flow).
 
 ### RTT-based time interval
 It may be desirable to use a more dynamic time limit, which is
-adapted to each flow. One way to do this, would be do base the time
+adapted to each flow. One way to do this, would be to base the time
 limit on the RTT for the flow. Flows with short RTTs could be expected
 to undergo more rapid changes than flows with long RTTs. This would
 require keeping track of the RTT for each flow, for example a moving
@@ -81,9 +81,9 @@ used, it should probably be user configurable (including allowing the
 user to disable sampling entirely).
 
 ## Allowing bursts
-It may be desirable to allow to allow for multiple packets in a short
+It may be desirable to allow for multiple packets in a short
 burst to be timestamped. Due to delayed ACKs, one may only get a
-response for every other packet. If the first packed is timestamped,
+response for every other packet. If the first packet is timestamped,
 and shortly after a second packet is sent (that has a different
 identifier), then the response will effectively be for the second
 packet, and no match for the timestamped identifier will be found. For
@@ -94,18 +94,18 @@ acknowledge multiple packets, then you essentially have a 50/50 chance
 of timestamping the wrong identifier and miss the RTT.
 
 To handle this, you could timestamp multiple consecutive packets (with
-unique indentifiers) in a short burst. You probably need to limit this
+unique identifiers) in a short burst. You probably need to limit this
 burst in both number of packets, as well as timeframe after the first
 packet that additional packets may be included. For example, allowing
-up to 3 packets (with different identifiers) get a timestamp for up to
-4 ms after the first one of them are timestamped.
+up to 3 packets (with different identifiers) to get a timestamp for up
+to 4 ms after the first one of them is timestamped.
 
 If allowing bursts of timestamps to be created, it may also be
 desirable to rate limit the output, in order to not get a burst of
 similar RTTs for the flow in the output (which may also skew averages
 and other post-processing).
 
-## Handing duplicate identifiers
+## Handling duplicate identifiers
 TCP timestamps are only updated at a limited rate (ex. 1000 Hz), and
 thus you can have multiple consecutive packets with the same TCP
 timestamp if they're sent fast enough. For the calculated RTT to be
@@ -114,14 +114,14 @@ identifier with the first received packet with a matching
 identifier. Otherwise, you may for example have a sequence with 100
 packets with the same identifier, and match the last of the outgoing
 packets with the first incoming response, which may underestimate the
-RTT with as much as the TCP timestamp clock rate (ex. 1 ms). 
+RTT by as much as the TCP timestamp clock rate (ex. 1 ms). 
 
 ### Current solution
 The current solution to this is very simple. For outgoing packets, a
 timestamp entry is only allowed to be created if no previous entry for
 the identifier exists (realized through the `BPF_NOEXIST` flag to
 `bpf_map_update_elem()` call). Thus only the first outgoing packet with
-a specific identifier can be timestamped. On egress, the first packet
+a specific identifier can be timestamped. On ingress, the first packet
 with a matching identifier will mark the timestamp as used, preventing
 later incoming responses from using that timestamp. The reason why the
 timestamp is marked as used rather than directly deleted once a
@@ -135,7 +135,7 @@ in the original pping, as explained
 ### New solution
 The current solution will no longer work if sampling is
 introduced. With sampling, there's no guarantee that the sampled
-packed will be the first outgoing packet in the sequence of packets
+packet will be the first outgoing packet in the sequence of packets
 with identical timestamps. Thus the RTT may still be underestimated by
 as much as the TCP timestamp clock rate (ex. 1 ms). Therefore, a new
 solution is needed. The current idea is to keep track of the last-seen
@@ -167,8 +167,8 @@ identifier may then be considered new (as it differs from the current
 one), allowing an entry to be created for it and reverting the last
 seen identifier to a previous one. Additionally, this may
 now allow the next packet having what used to be the current
-identifier, also being detected as a new identifier (as the out-of
-order packet reverted the last-seen identifier to an old one, creating
+identifier, also being detected as a new identifier (as the out-of-order
+packet reverted the last-seen identifier to an old one, creating
 a bit of a ping-pong effect). For TCP timestamps this can easily be
 avoided by simply requiring the new identifier to be greater than the
 last-seen identifier (as TCP timestamps should be monotonically
@@ -215,19 +215,19 @@ idea for a few reasons:
 
 1. The sampling rate would be inherently tied to the RTT of the
    flow. While this may in many cases be desirable, it is not very
-   flexible. It would also make it hard to ex. turn of sampling
+   flexible. It would also make it hard to ex. turn off sampling
    completely.
 2. The number of timestamps per flow would need to be fixed and known
    at compile time(?). As the timestamps/identifier pairs are kept in
-   the state-flow information itself, and the state-flow information
+   the flow-state information itself, and the flow-state information
    needs to be of a known and fixed size when creating the maps. This
    may also result in some wasted space if the flow-state includes
    spots for several timestamp/identifier pairs, but most flows only
    makes use of a few (although having an additional timestamp entry
    map of fixed size wastes space in a similar manner).
-2. If a low number of timestamp/identifier pairs are kept, selecting
+3. If a low number of timestamp/identifier pairs are kept, selecting
    an identifier that is missed (ex due to delayed ACKs) could
-   effectivly block new timestamps from being created (and thus from
+   effectively block new timestamps from being created (and thus from
    RTTs being calculated) for the flow for a relatively long
    while. New timestamps can only be created if you have a free slot,
    and you can only free a slot by either getting a matching reply, or
@@ -252,12 +252,12 @@ flows over smaller flows, as heavy flows are more likely to be able to
 get in a packet first, but they will at least still be limited by the
 rate limit, and thus have to take turns with other flows.
 
-It also worth noting that as per-flow state will need to be kept,
-there will be strict limit to the number of concurrent flows that can
+It is also worth noting that as per-flow state will need to be kept,
+there will be a strict limit to the number of concurrent flows that can
 be monitored, corresponding to the number of entries that can be held
 by the map for the per-flow state. Once the per-flow state map is
 full, no new flows can be added until one is cleared. It also doesn't
-make sense to add packet timestamp entries for flows which state
+make sense to add packet timestamp entries for flows whose state
 cannot be tracked, as the rate limit cannot be enforced then.
 
 I see a few ways to more actively handle degradation, depending on what
@@ -274,7 +274,7 @@ one views as desirable:
    to more quickly allow new flows to be monitored, and only keeping
    the most active flows around.
 2. One can attempt to monitor fewer flows, but with more frequent RTT
-   calculations for each. The easiest way to achieve this is to
+   calculations for each. The easiest way to achieve this is
    probably to set a smaller size on the per-flow map relative to the
    per-packet timestamp map. In case one wants to primarily focus on
    heavier flows, one could possibly add ex. packet rate to the
@@ -302,7 +302,7 @@ implementing the sampling, some of which I'll try to address here.
 ## "Global" vs PERCPU maps
 In general, it's likely wise to go with PERCPU maps over "global" (aka
 non-PERCPU) maps whenever possible, as PERCPU maps should be more
-performant, and also avoids concurrency issues. But this only applies
+performant, and also avoid concurrency issues. But this only applies
 of course, if the BPF programs don't need to act on global state.
 
 For pping, I unfortunately see no way for the program to work with
@@ -310,7 +310,7 @@ only information local to each CPU core individually. The per-packet
 identifier and timestamps need to be global, as there is no guarantee
 that the same core that timestamped a packet will process the response
 for that packet. Likewise, the per-flow information, like the time of
-the last timestamping, also needs to be global. Otherwise rate limit
+the last timestamping, also needs to be global. Otherwise the rate limit
 would be per-CPU-per-flow rather than just per-flow.
 
 In practice, packets from the same flow are apparently often handled
@@ -357,17 +357,17 @@ for the flow.
 
 Overall, I don't think these concurrency issues are that severe, as
 they should still result in accurate RTTs, just some possible
-over-reporting. I don't believe these issues warrants the performance
+over-reporting. I don't believe these issues warrant the performance
 impact and potential code complexity of trying to synchronize
 access. Furthermore, from what I understand these concurrency issues
 are not too likely to occur in reality, as packets from the same flow
 are often processed on the same core.
 
 ## Global variable vs single-entry map
-With BTF, there seems like BPF programs now support the use of global
+With BTF, it seems like BPF programs now support the use of global
 variables. These global variables can supposedly be modified from user
 space, and should from what I've heard also be more efficient than map
-lookups. They therefore seem like promising way to pass some
+lookups. They therefore seem like a promising way to pass some
 user-configured options from userspace to the BPF programs.
 
 I would however need to lookup how to actually use these, as the

--- a/pping/TODO.md
+++ b/pping/TODO.md
@@ -35,9 +35,9 @@
     - Original pping checks if flow is bi-directional before adding
       timestamps, but this could miss shorter flows
 - [ ] Dynamically grow the maps if they are starting to get full
-- [ ] Use libxdp to load XDP program
 
 ## Done
+- [x] Use libxdp to load XDP program
 - [x] Clean up commits and add signed-off-by tags
 - [x] Add SPDX-license-identifier tags
 - [x] Format C-code in kernel style
@@ -57,7 +57,7 @@
     works for both pping implementations.
 - [x] Add timestamps to output (as original pping)
 - [x] Add support for other hooks
-  - TC-BFP on ingress instead of XDP
+  - TC-BPF on ingress instead of XDP
 - [x] Improve map cleaning:
   - [x] Use BPF iter to clean up maps with BPF programs instead of
         looping through entries in userspace.
@@ -75,8 +75,8 @@
 ## Limited information in different output formats
 The ppviz format is a bit limited in what information it can
 include. One of these limitations is that it does not include any
-protocol information as it was designed with only TCP in mind. If
-using PPing with other protocols than TCP may therefore not be
+protocol information as it was designed with only TCP in mind. When
+using PPing with other protocols than TCP it may therefore not be
 possible to distinguish flows with different protocols. PPing will
 therefore emit a warning if attempting to use the ppviz format with
 protocols other than TCP, but will still allow it.
@@ -91,8 +91,8 @@ deemed important.
 
 ## Cannot detect end of ICMP "flow"
 ICMP is not a flow-based protocol, and therefore there is no signaling
-that the ICMP "flow" is about to close. Subsequently, there is not way
-for PPing to automatically detect that and ICMP flow has stopped and
+that the ICMP "flow" is about to close. Subsequently, there is no way
+for PPing to automatically detect that an ICMP flow has stopped and
 delete its flow-state entry (and send a timely flow closing event).
 
 A consequence of this is that the ICMP flow entries will stick around
@@ -103,11 +103,11 @@ the flow map and potentially block other flows for a considerable
 time.
 
 ## RTT-based sampling
-The RTT-based sampling features means that timestamp entries may only
-be created at an interval proportional to the flows RTT. This allows
+The RTT-based sampling feature means that timestamp entries may only
+be created at an interval proportional to the flow's RTT. This allows
 flows with shorter RTTs to get more frequent RTT samples than flows
-with long RTTs. However, as the flows RTT can only be updated based on
-the calculated RTT samples, this creates a situation where the RTTs
+with long RTTs. However, as the flow's RTT can only be updated based on
+the calculated RTT samples, this creates a situation where the RTT's
 update rate is dependent on itself. Flows with short RTTs will update
 the RTT more often, which in turn affects how often they can update
 the RTT.
@@ -116,7 +116,7 @@ This mainly becomes problematic if basing the sampling rate on the
 sRTT which may grow. In this case the sRTT will generally be prone to
 growing faster than it shrinks, as if it starts with a low RTT it will
 quickly update it to higher RTTs, but with high RTTs it will take
-longer for it do decrease to a lower RTT again.
+longer for it to decrease to a lower RTT again.
 
 ## Losing debug/warning information
 The "map full" and "map cleaning" events are pushed through the same
@@ -160,13 +160,13 @@ entry is deleted and there are other entries remaining in the same
 bucket, those remaining entries will not be traversed. As the
 periodical cleanup may delete entries as it is traversing the map,
 this may result in some of the entries which share the bucket
-with deleted entries not always be traversed.
+with deleted entries not always being traversed.
 
 In general this should not cause a large problem as those entries will
 simply be traversed the next time the map is iterated over
 instead. However, it may cause certain entries to remain in the hash
 map a bit longer than expected (and if the map is full subsequently
-block new entries from being created for that duration)
+block new entries from being created for that duration).
 
 
 ## Concurrency issues
@@ -197,7 +197,7 @@ for each flow, by storing it in the `flow_state` map. This is done to
 detect the first packet with a new identifier. If multiple packets are
 processed concurrently, several of them could potentially detect
 themselves as being first with the same identifier (which only matters
-if they also pass rate-limit check as well), alternatively if the
+if they also pass the rate-limit check), alternatively if the
 concurrent packets have different identifiers there may be a lost
 update (but for TCP timestamps, concurrent packets would typically be
 expected to have the same timestamp).
@@ -238,7 +238,7 @@ Both the tc/egress and XDP/ingress programs will try to update some
 flow statistics each time they successfully parse a packet with an
 identifier. Specifically, they'll update the number of packets and
 bytes sent/received. This is not done in an atomic fashion, so there
-could potentially be some lost updates resulting an underestimate.
+could potentially be some lost updates resulting in an underestimate.
 
 Furthermore, whenever the XDP/ingress program calculates an RTT, it
 will check if this is the lowest RTT seen so far for the flow. If


### PR DESCRIPTION
Fixes for the pping documentation (README, TODO, SAMPLING_DESIGN). Three factual corrections:

- README described the packet capture as XDP on ingress and TC-BPF on egress, but the default ingress hook is tc and XDP is opt-in through `--ingress-hook`, so it now reads "XDP or TC-BPF (on ingress)".
- TODO listed "Use libxdp to load XDP program" as open; it is done (78b45bd), so it moved to the Done section.
- SAMPLING_DESIGN said the first packet with a matching identifier marks the timestamp as used "on egress"; matching happens on ingress.

The rest is spelling, grammar and markdown fixes (including a broken image tag and a misnumbered list) without changing the meaning. I also checked the numeric claims against the code (ICMP flow timeout, timestamp lifetime relative to sRTT, cleanup rate, per-CPU counter maps) and the external links; those are correct and untouched. One thing I did not touch: the `rec_bytes` value in the README's RTT-event example (37 bytes for 5922 received packets) looks off, but I cannot produce a verified replacement.

A few features are not covered by the documentation. I left them out to keep this PR to fixes — would you like any of them added in a follow-up?

- the `--aggregate` options
- the systemd-files/ and scripts/ directories
- TCX attachment (#145)
