### PR TITLE
pping: append to an existing file for line-based output formats

### DIFF
--- a/pping/pping.c
+++ b/pping/pping.c
@@ -2232,7 +2232,13 @@ static struct output_context *open_output(const char *filename,
 	out_ctx->format = format;
 
 	if (filename) {
-		out_ctx->stream = fopen(filename, "ax");
+		/*
+		 * json wraps events in an array and can't be appended to;
+		 * standard, ppviz and jsonl are line-based and can be appended.
+		 */
+		const char *mode = format == PPING_OUTPUT_JSON ? "ax" : "a";
+
+		out_ctx->stream = fopen(filename, mode);
 		if (!out_ctx->stream)
 			goto err;
 	} else {


### PR DESCRIPTION
I run pping as a systemd service on my router, writing `jsonl` to a per-interface log with `-w`. `-w`/`--write` opens the file with `fopen(..., "ax")`, which fails when the file already exists — so every service restart needs the previous log moved away first.

The exclusive create protects the `json` format: it wraps all events in one array, so appending to an existing file yields invalid JSON. The other file formats (`standard`, `ppviz` and `jsonl`) are line-based and append safely, so open them with `"a"` and keep `"ax"` for `json` only. The shipped systemd unit (`pping/systemd-files`) moves the old log away before start and uses the `json` format, so its behaviour is unchanged.

Tested on the 3-uplink PPPoE router from the previous PRs: the services keep appending to the same logs across restarts, and logrotate's scheduled daily rename + SIGHUP cycle rotated all three logs and pping kept writing to the fresh files, with no reopen errors in either case.
