### PR TITLE
lib/util: don't emit a blank line when destroying a line-delimited json_writer

### DIFF
--- a/lib/util/json_writer.c
+++ b/lib/util/json_writer.c
@@ -113,7 +113,9 @@ void jsonw_destroy(json_writer_t **self_p)
 	json_writer_t *self = *self_p;
 
 	assert(self->depth == 0);
-	fputs("\n", self->out);
+	/* In line-delimited mode each object already ends with a newline */
+	if (!self->line_delimited)
+		fputs("\n", self->out);
 	fflush(self->out);
 	free(self);
 	*self_p = NULL;


### PR DESCRIPTION
The jsonl format from #142 leaves a blank line in the output at every shutdown and SIGHUP reopen: each object is already newline-terminated, so the unconditional newline in `jsonw_destroy()` adds an empty line. I noticed blank lines in the per-uplink logs on my router at service-restart boundaries.

Verified on the router: after a clean stop the log now ends with the last object's newline (`tail -c 3` shows `"}\n`, previously `}\n\n`), and the same after a SIGHUP reopen. The json array format keeps its final newline after the closing bracket.
