### PR TITLE
pping: only print usage for invalid arguments

### DIFF
--- a/pping/pping.c
+++ b/pping/pping.c
@@ -2836,9 +2836,11 @@ int main(int argc, char *argv[])
 
 	err = parse_arguments(argc, argv, &config);
 	if (err) {
-		fprintf(stderr, "Failed parsing arguments:  %s\n",
+		fprintf(stderr, "Failed parsing arguments: %s\n",
 			get_libbpf_strerror(err));
-		print_usage(argv);
+		/* Usage text does not help with e.g. a missing interface */
+		if (err == -EINVAL)
+			print_usage(argv);
 		return EXIT_FAILURE;
 	}
 

--- a/pping/pping.c
+++ b/pping/pping.c
@@ -332,7 +332,7 @@ static int parse_arguments(int argc, char *argv[], struct pping_config *config)
 			len = strlen(optarg);
 			if (len >= IF_NAMESIZE) {
 				fprintf(stderr, "interface name too long\n");
-				return -EINVAL;
+				return -ENAMETOOLONG;
 			}
 			memcpy(config->ifname, optarg, len);
 			config->ifname[len] = '\0';


### PR DESCRIPTION
Follow-up to #149: when systemd restarts pping while the monitored interface is still gone, every failed attempt printed the full usage text into the journal after "Could not get index of interface X: No such device". Now only genuine argument errors print the usage text.

Verified on the router running this change:

```
# pping -i nonexistent0
Could not get index of interface nonexistent0: No such device
Failed parsing arguments: No such device
```

and an unknown option still prints the usage text.

LLM assistance was used for the investigation, the patch and this description.
