### PR TITLE
lib: update libbpf submodule to v1.7.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/libbpf"]
 	path = lib/libbpf
-	url = https://github.com/xdp-project/libbpf.git
+	url = https://github.com/libbpf/libbpf.git
 	ignore = dirty
 [submodule "lib/xdp-tools"]
 	path = lib/xdp-tools


### PR DESCRIPTION
Ubuntu 26.04 (gcc 15.2 + glibc 2.43) no longer builds the tree: glibc's C23 const-preserving strchr() turns a pointer assignment in libbpf v1.3.0's resolve_full_path() into -Werror=discarded-qualifiers. Dates and details in the commit message; reproduce with `make` in an ubuntu:26.04 container.

With this bump the full tree builds on both 24.04 and 26.04: https://github.com/tobiaspal/bpf-examples/actions/runs/30680099284 (the workflow from #153).

The commit also points the submodule at upstream libbpf/libbpf, since the xdp-project/libbpf mirror currently ends at v1.5.0 — happy to keep the mirror instead if you prefer to update it.

Heads-up: xdp-tools vendors libbpf v1.5.0, so standalone xdp-tools builds hit the same problem on 26.04; separate from this PR.

LLM assistance was used for the root-cause analysis, the fix and this description.
